### PR TITLE
Fixes for public pkcs11.h header

### DIFF
--- a/tests/pkcs11mtt.c
+++ b/tests/pkcs11mtt.c
@@ -1816,7 +1816,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
     byte wrappedKey[32], wrappingKeyData[32], keyData[32];
     CK_ULONG wrappedKeyLen;
     CK_ATTRIBUTE tmpl[] = {
-      {CKA_VALUE, NULL_PTR, 0}
+      {CKA_VALUE, CK_NULL_PTR, 0}
     };
     CK_ULONG     tmplCnt = sizeof(tmpl) / sizeof(*tmpl);
 
@@ -3358,7 +3358,7 @@ static CK_RV extract_secret(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
 {
     CK_RV ret = CKR_OK;
     CK_ATTRIBUTE tmpl[] = {
-      {CKA_VALUE, NULL_PTR, 0}
+      {CKA_VALUE, CK_NULL_PTR, 0}
     };
     CK_ULONG     tmplCnt = sizeof(tmpl) / sizeof(*tmpl);
 

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -2635,7 +2635,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
     byte wrappedKey[32], wrappingKeyData[32], keyData[32];
     CK_ULONG wrappedKeyLen;
     CK_ATTRIBUTE tmpl[] = {
-      {CKA_VALUE, NULL_PTR, 0}
+      {CKA_VALUE, CK_NULL_PTR, 0}
     };
     CK_ULONG     tmplCnt = sizeof(tmpl) / sizeof(*tmpl);
 
@@ -4132,7 +4132,7 @@ static CK_RV extract_secret(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
 {
     CK_RV ret = CKR_OK;
     CK_ATTRIBUTE tmpl[] = {
-      {CKA_VALUE, NULL_PTR, 0}
+      {CKA_VALUE, CK_NULL_PTR, 0}
     };
     CK_ULONG     tmplCnt = sizeof(tmpl) / sizeof(*tmpl);
 

--- a/wolfpkcs11/pkcs11.h
+++ b/wolfpkcs11/pkcs11.h
@@ -22,7 +22,6 @@
 #ifndef _PKCS11_H_
 #define _PKCS11_H_
 
-#include <wolfpkcs11/config.h>
 #include <wolfpkcs11/visibility.h>
 
 #ifdef __cplusplus
@@ -35,6 +34,7 @@ extern "C" {
 #define CK_TRUE         1
 #define CK_FALSE        0
 
+#define CK_NULL_PTR     NULL_PTR
 
 #define CRYPTOKI_VERSION_MAJOR          2
 #define CRYPTOKI_VERSION_MINOR          40
@@ -106,15 +106,19 @@ extern "C" {
 #define CKS_RW_USER_FUNCTIONS                 3UL
 #define CKS_RW_SO_FUNCTIONS                   4UL
 
+#define CKO_DATA                              0x00000000UL
+#define CKO_CERTIFICATE                       0x00000001UL
 #define CKO_PUBLIC_KEY                        0x00000002UL
 #define CKO_PRIVATE_KEY                       0x00000003UL
 #define CKO_SECRET_KEY                        0x00000004UL
+
 
 #define CKK_RSA                               0x00000000UL
 #define CKK_DH                                0x00000002UL
 #define CKK_EC                                0x00000003UL
 #define CKK_GENERIC_SECRET                    0x00000010UL
 #define CKK_AES                               0x0000001FUL
+#define CKK_DES3                              0x00000015UL /* not supported */
 
 #define CKA_CLASS                             0x00000000UL
 #define CKA_TOKEN                             0x00000001UL
@@ -203,23 +207,51 @@ extern "C" {
 #define CKM_AES_GCM                           0x00001087UL
 
 #define CKR_OK                                0x00000000UL
+#define CKR_CANCEL                            0x00000001UL
+#define CKR_HOST_MEMORY                       0x00000002UL
 #define CKR_SLOT_ID_INVALID                   0x00000003UL
+#define CKR_GENERAL_ERROR                     0x00000005UL
 #define CKR_FUNCTION_FAILED                   0x00000006UL
 #define CKR_ARGUMENTS_BAD                     0x00000007UL
+#define CKR_NO_EVENT                          0x00000008UL
+#define CKR_NEED_TO_CREATE_THREADS            0x00000009UL
+#define CKR_CANT_LOCK                         0x0000000AUL
+#define CKR_ATTRIBUTE_READ_ONLY               0x00000010UL
+#define CKR_ATTRIBUTE_SENSITIVE               0x00000011UL
 #define CKR_ATTRIBUTE_TYPE_INVALID            0x00000012UL
 #define CKR_ATTRIBUTE_VALUE_INVALID           0x00000013UL
 #define CKR_ACTION_PROHIBITED                 0x0000001BUL
+#define CKR_DATA_INVALID                      0x00000020UL
 #define CKR_DATA_LEN_RANGE                    0x00000021UL
+#define CKR_DEVICE_ERROR                      0x00000030UL
 #define CKR_DEVICE_MEMORY                     0x00000031UL
+#define CKR_DEVICE_REMOVED                    0x00000032UL
+#define CKR_ENCRYPTED_DATA_INVALID            0x00000040UL
+#define CKR_ENCRYPTED_DATA_LEN_RANGE          0x00000041UL
+#define CKR_FUNCTION_CANCELED                 0x00000050UL
 #define CKR_FUNCTION_NOT_PARALLEL             0x00000051UL
 #define CKR_FUNCTION_NOT_SUPPORTED            0x00000054UL
+#define CKR_KEY_HANDLE_INVALID                0x00000060UL
+#define CKR_KEY_SIZE_RANGE                    0x00000062UL
 #define CKR_KEY_TYPE_INCONSISTENT             0x00000063UL
+#define CKR_KEY_NOT_NEEDED                    0x00000064UL
+#define CKR_KEY_CHANGED                       0x00000065UL
+#define CKR_KEY_NEEDED                        0x00000066UL
+#define CKR_KEY_INDIGESTIBLE                  0x00000067UL
+#define CKR_KEY_FUNCTION_NOT_PERMITTED        0x00000068UL
+#define CKR_KEY_NOT_WRAPPABLE                 0x00000069UL
+#define CKR_KEY_UNEXTRACTABLE                 0x0000006AUL
 #define CKR_MECHANISM_INVALID                 0x00000070UL
 #define CKR_MECHANISM_PARAM_INVALID           0x00000071UL
 #define CKR_OBJECT_HANDLE_INVALID             0x00000082UL
 #define CKR_OPERATION_ACTIVE                  0x00000090UL
 #define CKR_OPERATION_NOT_INITIALIZED         0x00000091UL
 #define CKR_PIN_INCORRECT                     0x000000A0UL
+#define CKR_PIN_INVALID                       0x000000A1UL
+#define CKR_PIN_LEN_RANGE                     0x000000A2UL
+#define CKR_PIN_EXPIRED                       0x000000A3UL
+#define CKR_PIN_LOCKED                        0x000000A4UL
+#define CKR_SESSION_CLOSED                    0x000000B0UL
 #define CKR_SESSION_COUNT                     0x000000B1UL
 #define CKR_SESSION_HANDLE_INVALID            0x000000B3UL
 #define CKR_SESSION_PARALLEL_NOT_SUPPORTED    0x000000B4UL
@@ -228,16 +260,40 @@ extern "C" {
 #define CKR_SESSION_READ_ONLY_EXISTS          0x000000B7UL
 #define CKR_SESSION_READ_WRITE_SO_EXISTS      0x000000B8UL
 #define CKR_SIGNATURE_INVALID                 0x000000C0UL
+#define CKR_SIGNATURE_LEN_RANGE               0x000000C1UL
 #define CKR_TEMPLATE_INCOMPLETE               0x000000D0UL
 #define CKR_TEMPLATE_INCONSISTENT             0x000000D1UL
+#define CKR_TOKEN_NOT_PRESENT                 0x000000E0UL
+#define CKR_TOKEN_NOT_RECOGNIZED              0x000000E1UL
+#define CKR_TOKEN_WRITE_PROTECTED             0x000000E2UL
+#define CKR_UNWRAPPING_KEY_HANDLE_INVALID     0x000000F0UL
+#define CKR_UNWRAPPING_KEY_SIZE_RANGE         0x000000F1UL
+#define CKR_UNWRAPPING_KEY_TYPE_INCONSISTENT  0x000000F2UL
 #define CKR_USER_ALREADY_LOGGED_IN            0x00000100UL
 #define CKR_USER_NOT_LOGGED_IN                0x00000101UL
 #define CKR_USER_PIN_NOT_INITIALIZED          0x00000102UL
 #define CKR_USER_TYPE_INVALID                 0x00000103UL
+#define CKR_USER_ANOTHER_ALREADY_LOGGED_IN    0x00000104UL
+#define CKR_USER_TOO_MANY_TYPES               0x00000105UL
+#define CKR_WRAPPED_KEY_INVALID               0x00000110UL
+#define CKR_WRAPPED_KEY_LEN_RANGE             0x00000112UL
+#define CKR_WRAPPING_KEY_HANDLE_INVALID       0x00000113UL
+#define CKR_WRAPPING_KEY_SIZE_RANGE           0x00000114UL
+#define CKR_WRAPPING_KEY_TYPE_INCONSISTENT    0x00000115UL
+#define CKR_RANDOM_SEED_NOT_SUPPORTED         0x00000120UL
+#define CKR_RANDOM_NO_RNG                     0x00000121UL
+#define CKR_DOMAIN_PARAMS_INVALID             0x00000130UL
 #define CKR_BUFFER_TOO_SMALL                  0x00000150UL
 #define CKR_SAVED_STATE_INVALID               0x00000160UL
+#define CKR_INFORMATION_SENSITIVE             0x00000170UL
 #define CKR_STATE_UNSAVEABLE                  0x00000180UL
 #define CKR_CRYPTOKI_NOT_INITIALIZED          0x00000190UL
+#define CKR_CRYPTOKI_ALREADY_INITIALIZED      0x00000191UL
+#define CKR_MUTEX_BAD                         0x000001A0UL
+#define CKR_MUTEX_NOT_LOCKED                  0x000001A1UL
+#define CKR_FUNCTION_REJECTED                 0x00000200UL
+#define CKR_VENDOR_DEFINED                    0x80000000UL
+
 
 #define CKD_NULL                              0x00000001UL
 
@@ -262,7 +318,6 @@ typedef CK_UTF8CHAR*      CK_UTF8CHAR_PTR;
 typedef CK_ULONG*         CK_ULONG_PTR;
 typedef void*             CK_VOID_PTR;
 typedef CK_VOID_PTR*      CK_VOID_PTR_PTR;
-
 
 typedef CK_ULONG          CK_RV;
 


### PR DESCRIPTION
* Remove `config.h` from the public pkcs11.h header.
* Add some missing PKCS11 types.
ZD 13236