### PR TITLE
Fix for `WP11_API` visibility

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -20,6 +20,10 @@
  */
 
 
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
 #include <wolfssl/options.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -20,6 +20,10 @@
  */
 
 
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
 #include <wolfssl/options.h>
 #include <wolfssl/wolfcrypt/pwdbased.h>
 #include <wolfssl/wolfcrypt/asn.h>

--- a/src/slot.c
+++ b/src/slot.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
 #include <wolfpkcs11/pkcs11.h>
 #include <wolfpkcs11/internal.h>
 

--- a/src/wolfpkcs11.c
+++ b/src/wolfpkcs11.c
@@ -19,6 +19,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
 #include <wolfpkcs11/pkcs11.h>
 #include <wolfpkcs11/internal.h>
 


### PR DESCRIPTION
If `config.h` is not included, the `HAVE_VISIBILITY` macro will not be set. ZD13236