### PR TITLE
Fix for FIPS and pin length

### DIFF
--- a/tests/pkcs11mtt.c
+++ b/tests/pkcs11mtt.c
@@ -47,9 +47,12 @@ static void* dlib;
 static CK_FUNCTION_LIST* funcList;
 static int slot;
 const char* tokenName = "wolfpkcs11";
-static byte* soPin = (byte*)"password";
-static int soPinLen = 8;
-byte* userPin = (byte*)"wolfpkcs11";
+
+/* FIPS requires pin to be at least 14 characters, since it is used for
+ * the HMAC key */
+static byte* soPin = (byte*)"password123456";
+static int soPinLen = 14;
+byte* userPin = (byte*)"wolfpkcs11-test";
 int userPinLen;
 
 #if !defined(NO_RSA) || defined(HAVE_ECC) || !defined(NO_DH)

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -60,9 +60,12 @@ static void* dlib;
 static CK_FUNCTION_LIST* funcList;
 static int slot = 0;
 const char* tokenName = "wolfpkcs11";
-static byte* soPin = (byte*)"password";
-static int soPinLen = 8;
-byte* userPin = (byte*)"wolfpkcs11";
+
+/* FIPS requires pin to be at least 14 characters, since it is used for
+ * the HMAC key */
+static byte* soPin = (byte*)"password123456";
+static int soPinLen = 14;
+byte* userPin = (byte*)"wolfpkcs11-test";
 int userPinLen;
 
 #if !defined(NO_RSA) || defined(HAVE_ECC) || !defined(NO_DH)


### PR DESCRIPTION
Fix for test pin to be at least 14-characters as required by FIPS HMAC. ZD13122