### PR TITLE
Add support for wrap/unwrap RSA with aes_cbc_pad.

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -192,19 +192,23 @@ static void FindAttributeType(CK_ATTRIBUTE* pTemplate, CK_ULONG ulCount,
 
     *attribute = NULL;
     for (i = 0; i < (int)ulCount; i++) {
-        if (pTemplate[i].type == type)
+        if (pTemplate[i].type == type) {
             *attribute = &pTemplate[i];
+        }
     }
 }
 
 static CK_RV FindValidAttributeType(CK_ATTRIBUTE* pTemplate, CK_ULONG ulCount,
-                                    CK_ATTRIBUTE_TYPE type, CK_ATTRIBUTE** attr, size_t sz) {
+                        CK_ATTRIBUTE_TYPE type, CK_ATTRIBUTE** attr, size_t sz)
+{
     FindAttributeType(pTemplate, ulCount, type, attr);
-    if (*attr == NULL)
+    if (*attr == NULL) {
         return CKR_TEMPLATE_INCOMPLETE;
+    }
 
-    if ((*attr)->pValue == NULL || (*attr)->ulValueLen != sz)
+    if ((*attr)->pValue == NULL || (*attr)->ulValueLen != sz) {
         return CKR_ATTRIBUTE_VALUE_INVALID;
+    }
 
     return CKR_OK;
 }
@@ -491,7 +495,7 @@ static CK_RV AddObject(WP11_Session* session, WP11_Object* object,
  * @param  pTemplate  [in]   Template of attributes for object.
  * @param  ulCount    [in]   Number of attribute triplets in template.
  * @param  derBuf     [in]   DER-encoded private key
- * @param  derlen     [in]   Length of the DER-encoded key data
+ * @param  derLen     [in]   Length of the DER-encoded key data
  * @param  phKey      [out]  pointer to hold the handle to the new key object
  * @return  CKR_CRYPTOKI_NOT_INITIALIZED when library not initialized.
  *          CKR_SESSION_HANDLE_INVALID when session handle is not valid.
@@ -505,8 +509,9 @@ static CK_RV AddObject(WP11_Session* session, WP11_Object* object,
  *          CKR_WRAPPED_KEY_INVALID when DER-encoded key data isn't valid
  *          CKR_OK on success.
  */
-static CK_RV AddRSAPrivateKeyObject(WP11_Session* session, CK_ATTRIBUTE_PTR pTemplate,
-                                    CK_ULONG ulCount, byte* derBuf, CK_ULONG derLen, CK_OBJECT_HANDLE_PTR phKey)
+static CK_RV AddRSAPrivateKeyObject(WP11_Session* session,
+    CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount, byte* derBuf, CK_ULONG derLen,
+    CK_OBJECT_HANDLE_PTR phKey)
 {
     CK_RV rv;
     WP11_Object* privKeyObject = NULL;
@@ -516,11 +521,10 @@ static CK_RV AddRSAPrivateKeyObject(WP11_Session* session, CK_ATTRIBUTE_PTR pTem
     rv = NewObject(session, CKK_RSA, CKO_PRIVATE_KEY,
                    pTemplate, ulCount,
                    &privKeyObject);
-
     if (rv != CKR_OK)
         return rv;
 
-    if ( WP11_Rsa_ParsePrivKey(derBuf, (word32)derLen, privKeyObject) != 0 ) {
+    if (WP11_Rsa_ParsePrivKey(derBuf, (word32)derLen, privKeyObject) != 0 ) {
         rv = CKR_WRAPPED_KEY_INVALID;
         goto err_out;
     }
@@ -542,7 +546,7 @@ static CK_RV AddRSAPrivateKeyObject(WP11_Session* session, CK_ATTRIBUTE_PTR pTem
 
         CK_OBJECT_HANDLE hPub;
 
-        CK_ATTRIBUTE      pubt[] = {
+        CK_ATTRIBUTE pubt[] = {
                 {CKA_TOKEN,    NULL, sizeof(CK_BBOOL)},
                 {CKA_LABEL,    NULL, 0},
                 {CKA_WRAP,    &falseVal, sizeof(falseVal)},
@@ -574,28 +578,27 @@ static CK_RV AddRSAPrivateKeyObject(WP11_Session* session, CK_ATTRIBUTE_PTR pTem
         if (rv != CKR_OK)
             goto err_out;
 
-        if (WP11_Rsa_PrivKey2PubKey(privKeyObject, pubKeyObject, derBuf, (word32)derLen) == 0) {
-
-            rv = AddObject(session, pubKeyObject, pubt, sizeof(pubt) / sizeof(CK_ATTRIBUTE), &hPub);
-
+        if (WP11_Rsa_PrivKey2PubKey(privKeyObject, pubKeyObject, derBuf,
+                                                         (word32)derLen) == 0) {
+            rv = AddObject(session, pubKeyObject, pubt,
+                sizeof(pubt) / sizeof(CK_ATTRIBUTE), &hPub);
             if (rv != CKR_OK) {
                 WP11_Object_Free(pubKeyObject);
             }
-        } else {
+        }
+        else {
             rv = CKR_WRAPPED_KEY_INVALID;
             WP11_Object_Free(pubKeyObject);
         }
     }
-
 #endif
+
 err_out:
     if (rv != CKR_OK) {
-
         if (*phKey != CK_INVALID_HANDLE) {
             WP11_Session_RemoveObject(session, privKeyObject);
             *phKey = CK_INVALID_HANDLE;
         }
-
         if (privKeyObject != NULL) {
             WP11_Object_Free(privKeyObject);
         }
@@ -3849,11 +3852,11 @@ CK_RV C_WrapKey(CK_SESSION_HANDLE hSession,
     if (rv != CKR_OK)
         return rv;
 
-    switch(keyType) {
+    switch (keyType) {
 
         case CKK_RSA:
             ret = WP11_Rsa_SerializeKeyPTPKC8(key, NULL, &serialSize);
-            
+
             if (ret != 0)
                 return CKR_FUNCTION_FAILED;
 
@@ -3862,7 +3865,7 @@ CK_RV C_WrapKey(CK_SESSION_HANDLE hSession,
                 return CKR_HOST_MEMORY;
 
             ret = WP11_Rsa_SerializeKeyPTPKC8(key, serialBuff, &serialSize);
-           
+
             if (ret != 0)
                 return CKR_FUNCTION_FAILED;
 
@@ -3955,7 +3958,7 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
                                            pTemplate == NULL || phKey == NULL) {
         return CKR_ARGUMENTS_BAD;
     }
-    
+
     *phKey = CK_INVALID_HANDLE;
 
     ret = WP11_Object_Find(session, hUnwrappingKey, &unwrappingKey);
@@ -3966,32 +3969,27 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
         return CKR_MECHANISM_INVALID;
     }
 
-    rv = FindValidAttributeType(pTemplate, ulAttributeCount, CKA_KEY_TYPE, &attr, sizeof(CK_KEY_TYPE));
-
+    rv = FindValidAttributeType(pTemplate, ulAttributeCount, CKA_KEY_TYPE,
+        &attr, sizeof(CK_KEY_TYPE));
     if (rv != CKR_OK)
         return rv;
 
     keyType = *(CK_KEY_TYPE*)attr->pValue;
-
     rv = CHECK_KEYTYPE(keyType);
-
     if (rv != CKR_OK)
         return rv;
 
-    rv = FindValidAttributeType(pTemplate, ulAttributeCount, CKA_CLASS, &attr, sizeof(CK_OBJECT_CLASS));
-
+    rv = FindValidAttributeType(pTemplate, ulAttributeCount, CKA_CLASS, &attr,
+        sizeof(CK_OBJECT_CLASS));
     if (rv != CKR_OK)
         return rv;
 
     keyClass = *(CK_OBJECT_CLASS*)attr->pValue;
-
     rv = CHECK_KEYCLASS(keyClass);
-
     if (rv != CKR_OK)
         return rv;
 
     rv = CHECK_WRAPPABLE(keyClass, keyType);
-
     if (rv != CKR_OK)
         return rv;
 
@@ -4012,7 +4010,8 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
             if (rv != CKR_OK)
                 goto err_out;
 
-            rv = C_Decrypt(hSession, pWrappedKey, ulWrappedKeyLen, workBuffer, &ulUnwrappedLen);
+            rv = C_Decrypt(hSession, pWrappedKey, ulWrappedKeyLen, workBuffer,
+                &ulUnwrappedLen);
             if (rv != CKR_OK)
                 goto err_out;
 
@@ -4021,10 +4020,11 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
             return CKR_MECHANISM_INVALID;
     }
 
-    switch(keyType) {
+    switch (keyType) {
         case CKK_RSA:
 
-            rv = AddRSAPrivateKeyObject(session, pTemplate, ulAttributeCount, workBuffer, ulUnwrappedLen, phKey);
+            rv = AddRSAPrivateKeyObject(session, pTemplate, ulAttributeCount,
+                workBuffer, ulUnwrappedLen, phKey);
             break;
         default:
             rv = CKR_KEY_NOT_WRAPPABLE;
@@ -4033,7 +4033,7 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
 
     err_out:
 
-    if ( workBuffer != NULL) {
+    if (workBuffer != NULL) {
         XMEMSET(workBuffer, 0, ulWrappedKeyLen);
         XFREE(workBuffer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -3861,8 +3861,10 @@ CK_RV C_WrapKey(CK_SESSION_HANDLE hSession,
                 return CKR_HOST_MEMORY;
 
             ret = WP11_Rsa_SerializeKey(key,  serialBuff, &serialSize);
-            if (ret != 0)
-                return CKR_FUNCTION_FAILED;
+            if (ret != 0) {
+                rv = CKR_FUNCTION_FAILED;
+                goto err_out;
+            }
 
             break;
         default:

--- a/src/internal.c
+++ b/src/internal.c
@@ -1530,12 +1530,10 @@ int WP11_Rsa_SerializeKeyPTPKC8(WP11_Object* object, byte* output, word32* pouts
         return OBJ_TYPE_E;
 
     ret = WP11_Rsa_SerializeKey(object, NULL, &dersz);
-
     if (ret != 0)
         return ret;
 
     der = (unsigned char*)XMALLOC(dersz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-
     if (der == NULL)
         return MEMORY_E;
 
@@ -5957,16 +5955,15 @@ int WP11_Object_MatchAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
  * @return  -ve when key parse fails.
  *          0 on success.
  */
-int WP11_Rsa_ParsePrivKey(byte* data, word32 dataLen, WP11_Object* privKey) {
+int WP11_Rsa_ParsePrivKey(byte* data, word32 dataLen, WP11_Object* privKey)
+{
     int ret = 0;
     word32 idx = 0;
 
-    ret = wc_InitRsaKey(&(privKey->data.rsaKey), NULL);
-    if (ret != 0)
-        return ret;
-
-    ret = wc_RsaPrivateKeyDecode(data, &idx, &privKey->data.rsaKey, dataLen);
-
+    ret = wc_InitRsaKey(&privKey->data.rsaKey, NULL);
+    if (ret == 0) {
+        ret = wc_RsaPrivateKeyDecode(data, &idx, &privKey->data.rsaKey, dataLen);
+    }
     return ret;
 }
 
@@ -5980,21 +5977,23 @@ int WP11_Rsa_ParsePrivKey(byte* data, word32 dataLen, WP11_Object* privKey) {
  * @return  -ve when key parse fails.
  *          0 on success.
  */
-int WP11_Rsa_PrivKey2PubKey(WP11_Object* privKey, WP11_Object* pubKey, byte* workbuf, word32 worksz) {
+int WP11_Rsa_PrivKey2PubKey(WP11_Object* privKey, WP11_Object* pubKey,
+    byte* workbuf, word32 worksz)
+{
     int ret;
     word32 idx = 0;
 
     ret = wc_InitRsaKey(&pubKey->data.rsaKey, NULL);
-    if (ret != 0)
-        return ret;
-
-    ret = wc_RsaKeyToPublicDer(&privKey->data.rsaKey, workbuf, worksz);
-    if (ret < 0)
-        return ret;
-    else
-        worksz = (word32)ret;
-
-    ret = wc_RsaPublicKeyDecode(workbuf, &idx, &pubKey->data.rsaKey, worksz);
+    if (ret == 0) {
+        ret = wc_RsaKeyToPublicDer(&privKey->data.rsaKey, workbuf, worksz);
+        if (ret >= 0) {
+            worksz = (word32)ret;
+            ret = 0;
+        }
+    }
+    if (ret == 0) {
+        ret = wc_RsaPublicKeyDecode(workbuf, &idx, &pubKey->data.rsaKey, worksz);
+    }
 
     return ret;
 }

--- a/src/internal.c
+++ b/src/internal.c
@@ -35,6 +35,7 @@
 #include <wolfssl/wolfcrypt/asn.h>
 #include <wolfssl/wolfcrypt/hmac.h>
 #include <wolfssl/wolfcrypt/ecc.h>
+#include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/aes.h>
 
@@ -1451,6 +1452,53 @@ static int wp11_Object_Encode_RsaKey(WP11_Object* object)
         object->keyData = NULL;
         object->keyDataLen = 0;
     }
+
+    return ret;
+}
+
+/**
+ * Export the RSA key.
+ *
+ * Keys are encoded in DER.
+ *
+ * @param [in, out]  object  RSA key object.
+ * @param [out]  output  holds encoded key and can be null.
+ * @param [in/out]  poutsz  in and out size of output buffer
+ * @return  0 on success.
+ * @return  -ve on failure.
+ */
+int WP11_Rsa_SerializeKey(WP11_Object* object, byte* output, word32* poutsz)
+{
+    int ret;
+    word32 insz, outsz;
+
+    if (object == NULL || poutsz == NULL)
+        return PARAM_E;
+
+    insz = *poutsz;
+
+    if (object->type != CKK_RSA)
+        return OBJ_TYPE_E;
+
+    if (object->objClass == CKO_PRIVATE_KEY) {
+        /* Get length of encoded private key. */
+        ret = wc_RsaKeyToDer(&object->data.rsaKey, output, insz);
+        if (ret >= 0) {
+            outsz = ret;
+            ret = 0;
+        }
+    }
+    else {
+        /* Get length of encoded public key. */
+        ret = wc_RsaKeyToPublicDer(&object->data.rsaKey, output, insz);
+        if (ret >= 0) {
+            outsz = ret;
+            ret = 0;
+        }
+    }
+
+    if (ret == 0)
+        *poutsz = outsz;
 
     return ret;
 }
@@ -4493,6 +4541,17 @@ CK_KEY_TYPE WP11_Object_GetType(WP11_Object* object)
     return object->type;
 }
 
+/**
+ * Get the object's class.
+ *
+ * @param  object  [in]  Object object.
+ * @return  Object's class.
+ */
+CK_OBJECT_CLASS WP11_Object_GetClass(WP11_Object* object)
+{
+    return object->objClass;
+}
+
 #if !defined(NO_RSA) || defined(HAVE_ECC)
 /**
  * Set the multi-precision integer from the data.
@@ -5833,6 +5892,58 @@ int WP11_Object_MatchAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
 }
 
 #ifndef NO_RSA
+
+/**
+ * Internalize an RSA private key from DER form.
+ *
+ * @param  data   [in]  Buffer to parse
+ * @param  dataLen [in] size of buffer
+ * @param  privKey  [in/out]  Private key object.
+ * @return  -ve when key parse fails.
+ *          0 on success.
+ */
+int WP11_Rsa_ParsePrivKey(byte* data, word32 dataLen, WP11_Object* privKey) {
+    int ret = 0;
+    word32 idx = 0;
+
+    ret = wc_InitRsaKey(&(privKey->data.rsaKey), NULL);
+    if (ret != 0)
+        return ret;
+
+    ret = wc_RsaPrivateKeyDecode(data, &idx, &privKey->data.rsaKey, dataLen);
+
+    return ret;
+}
+
+/**
+ * Transfer public parts to RSA public key.
+ *
+ * @param  privKey   [in] holds modulus and pub exponent
+ * @param  pubKey [in/out] to be populated
+ * @param  workbuf  [in/out] used to serialize/parse.
+ * @param  worksz  [in] size of workbuf.
+ * @return  -ve when key parse fails.
+ *          0 on success.
+ */
+int WP11_Rsa_PrivKey2PubKey(WP11_Object* privKey, WP11_Object* pubKey, byte* workbuf, word32 worksz) {
+    int ret;
+    word32 idx = 0;
+
+    ret = wc_InitRsaKey(&pubKey->data.rsaKey, NULL);
+    if (ret != 0)
+        return ret;
+
+    ret = wc_RsaKeyToPublicDer(&privKey->data.rsaKey, workbuf, worksz);
+    if (ret < 0)
+        return ret;
+    else
+        worksz = (word32)ret;
+
+    ret = wc_RsaPublicKeyDecode(workbuf, &idx, &pubKey->data.rsaKey, worksz);
+
+    return ret;
+}
+
 #ifdef WOLFSSL_KEY_GEN
 /**
  * Generate an RSA key pair.

--- a/src/slot.c
+++ b/src/slot.c
@@ -325,7 +325,7 @@ static CK_MECHANISM_INFO rsaKgMechInfo = {
 #endif
 /* Info on RSA X.509 mechanism. */
 static CK_MECHANISM_INFO rsaX509MechInfo = {
-    1024, 4096, CKF_ENCRYPT | CKF_DECRYPT | CKF_SIGN | CKF_VERIFY
+    1024, 4096, CKF_ENCRYPT | CKF_DECRYPT | CKF_SIGN | CKF_VERIFY | CKF_WRAP | CKF_UNWRAP
 };
 /* Info on RSA PKCS#1.5 mechanism. */
 static CK_MECHANISM_INFO rsaPkcsMechInfo = {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,6 @@
+## wolfPKCS11 Tests
+
+The test files have the following purposes:
+* `pkcs11test.c`: is the standard tests
+* `pkcs11mtt.c`: is the multithreaded tests
+* `pkcs11str.c`: is a storage test

--- a/tests/include.am
+++ b/tests/include.am
@@ -23,4 +23,5 @@ tests_pkcs11str_LDADD  += src/libwolfpkcs11.la
 endif
 
 EXTRA_DIST += tests/unit.h \
-              tests/testdata.h
+              tests/testdata.h \
+              tests/README.md

--- a/tests/pkcs11mtt.c
+++ b/tests/pkcs11mtt.c
@@ -243,7 +243,7 @@ static CK_RV test_object(void* args)
     CK_ATTRIBUTE keyTypeZeroLen[] = {
         { CKA_KEY_TYPE,          &genericKeyType,   0,                        }
     };
-    CK_ULONG badKeyType = -1; 
+    CK_ULONG badKeyType = -1;
     CK_ATTRIBUTE keyTypeBadValue[] = {
         { CKA_KEY_TYPE,          &badKeyType,       sizeof(&badKeyType)       }
     };
@@ -272,7 +272,7 @@ static CK_RV test_object(void* args)
     CK_OBJECT_HANDLE objOnToken = CK_INVALID_HANDLE;
     CK_OBJECT_HANDLE copyObj = CK_INVALID_HANDLE;
     CK_ULONG size;
-    
+
 
     ret = funcList->C_CreateObject(CK_INVALID_HANDLE, tmpl, tmplCnt, &obj);
     CHECK_CKR_FAIL(ret, CKR_SESSION_HANDLE_INVALID,
@@ -1316,7 +1316,7 @@ static CK_RV test_sign_verify(void* args)
         mech.mechanism = CKM_AES_CBC;
         ret = funcList->C_SignInit(session, &mech, key);
         CHECK_CKR_FAIL(ret, CKR_MECHANISM_INVALID,
-                                              "HMAC Sign Init wrong mechansim");
+                                              "HMAC Sign Init wrong mechanism");
         mech.mechanism = CKM_SHA256_HMAC;
     }
     if (ret == CKR_OK) {
@@ -1382,7 +1382,7 @@ static CK_RV test_sign_verify(void* args)
         mech.mechanism = CKM_AES_CBC;
         ret = funcList->C_VerifyInit(session, &mech, key);
         CHECK_CKR_FAIL(ret, CKR_MECHANISM_INVALID,
-                                            "HMAC Verify Init wrong mechansim");
+                                            "HMAC Verify Init wrong mechanism");
         mech.mechanism = CKM_SHA256_HMAC;
     }
     if (ret == CKR_OK) {
@@ -1590,7 +1590,7 @@ static CK_RV test_encdec_digest(void* args)
     }
 
     if (ret == CKR_OK) {
-        ret = funcList->C_DecryptDigestUpdate(CK_INVALID_HANDLE, enc, encSz, 
+        ret = funcList->C_DecryptDigestUpdate(CK_INVALID_HANDLE, enc, encSz,
                                                                  data, &dataSz);
         CHECK_CKR_FAIL(ret, CKR_SESSION_HANDLE_INVALID,
                                 "Decrypt Digest Update invalid session handle");
@@ -1658,7 +1658,7 @@ static CK_RV test_encdec_signverify(void* args)
     }
 
     if (ret == CKR_OK) {
-        ret = funcList->C_DecryptVerifyUpdate(CK_INVALID_HANDLE, enc, encSz, 
+        ret = funcList->C_DecryptVerifyUpdate(CK_INVALID_HANDLE, enc, encSz,
                                                                  data, &dataSz);
         CHECK_CKR_FAIL(ret, CKR_SESSION_HANDLE_INVALID,
                                 "Decrypt Verify Update invalid session handle");
@@ -1847,7 +1847,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
     if (ret == CKR_OK) {
         ret = funcList->C_WrapKey(session, &mech, CK_INVALID_HANDLE, key,
                                                     wrappedKey, &wrappedKeyLen);
-        CHECK_CKR_FAIL(ret, CKR_OBJECT_HANDLE_INVALID,
+        CHECK_CKR_FAIL(ret, CKR_WRAPPING_KEY_HANDLE_INVALID,
                                         "Wrap Key invalid wrapping key handle");
     }
     if (ret == CKR_OK) {
@@ -1864,10 +1864,9 @@ static CK_RV test_wrap_unwrap_key(void* args)
     if (ret == CKR_OK) {
         ret = funcList->C_WrapKey(session, &mech, wrappingKey, key, wrappedKey,
                                                                 &wrappedKeyLen);
-        CHECK_CKR_FAIL(ret, CKR_MECHANISM_INVALID,
-                                            "Wrap Key mechansim not supported");
+        CHECK_CKR_FAIL(ret, CKR_KEY_NOT_WRAPPABLE,
+                                            "Wrap Key mechanism not supported");
     }
-
     if (ret == CKR_OK) {
         ret = funcList->C_UnwrapKey(CK_INVALID_HANDLE, &mech, wrappingKey,
                                        wrappedKey, wrappedKeyLen, tmpl, tmplCnt,
@@ -1884,7 +1883,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
         ret = funcList->C_UnwrapKey(session, &mech, CK_INVALID_HANDLE,
                                        wrappedKey, wrappedKeyLen, tmpl, tmplCnt,
                                        &key);
-        CHECK_CKR_FAIL(ret, CKR_OBJECT_HANDLE_INVALID,
+        CHECK_CKR_FAIL(ret, CKR_UNWRAPPING_KEY_HANDLE_INVALID,
                                       "Unwrap Key invalid wrapping key handle");
     }
     if (ret == CKR_OK) {
@@ -1912,7 +1911,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
         ret = funcList->C_UnwrapKey(session, &mech, wrappingKey, wrappedKey,
                                             wrappedKeyLen, tmpl, tmplCnt, &key);
         CHECK_CKR_FAIL(ret, CKR_MECHANISM_INVALID,
-                                          "Unwrap Key mechansim not supported");
+                                          "Unwrap Key mechanism not supported");
     }
 
     funcList->C_DestroyObject(session, wrappingKey);
@@ -2720,7 +2719,7 @@ static CK_RV test_rsa_fixed_keys_raw(void* args)
         ret = get_rsa_pub_key(session, NULL, 0, &pub);
     if (ret == CKR_OK)
         ret = rsa_raw_test(session, priv, pub);
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
 
@@ -2739,7 +2738,7 @@ static CK_RV test_rsa_fixed_keys_pkcs15_enc(void* args)
         ret = get_rsa_pub_key(session, NULL, 0, &pub);
     if (ret == CKR_OK)
         ret = rsa_pkcs15_enc_test(session, priv, pub);
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
 
@@ -2787,7 +2786,7 @@ static CK_RV test_rsa_fixed_keys_oaep(void* args)
                                                                        NULL, 0);
         CHECK_CKR(ret, "SHA512 No AAD");
     }
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
 
@@ -2821,7 +2820,7 @@ static CK_RV test_rsa_fixed_keys_pkcs15_sig(void* args)
         ret = rsa_pkcs15_sig_test(session, priv, pub, 64);
         CHECK_CKR(ret, "RSA PKCS#1.5 - 64 byte hash");
     }
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
 
@@ -2859,7 +2858,7 @@ static CK_RV test_rsa_fixed_keys_pss(void* args)
         ret = rsa_pss_test(session, priv, pub, CKM_SHA512, CKG_MGF1_SHA512, 64);
         CHECK_CKR(ret, "RSA PKCS#1 PSS - SHA512");
     }
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
 
@@ -2947,7 +2946,7 @@ static CK_RV rsa_encdec_fail(CK_SESSION_HANDLE session, CK_MECHANISM* mech,
     }
 
     funcList->C_DestroyObject(session, key);
-    
+
     return ret;
 }
 
@@ -2997,10 +2996,10 @@ static CK_RV test_rsa_x_509_fail(void* args)
                                        "RSA Decrypt Init bad parameter length");
         mech.ulParameterLen = 0;
     }
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
-    
+
     return ret;
 }
 
@@ -3050,7 +3049,7 @@ static CK_RV test_rsa_pkcs_encdec_fail(void* args)
                                        "RSA Decrypt Init bad parameter length");
         mech.ulParameterLen = 0;
     }
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
 
@@ -3124,7 +3123,7 @@ static CK_RV test_rsa_pkcs_oaep_encdec_fail(void* args)
                                                  "RSA Decrypt Init bad source");
         params.source = CKZ_DATA_SPECIFIED;
     }
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
 
@@ -3178,7 +3177,7 @@ static CK_RV test_rsa_pkcs_sig_fail(void* args)
                                             "Verify Init bad parameter length");
         mech.ulParameterLen = 0;
     }
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
 
@@ -3311,7 +3310,7 @@ static CK_RV test_rsa_gen_keys(void* args)
     if (ret == CKR_OK)
         ret = rsa_pss_test(session, priv, pub, CKM_SHA256, CKG_MGF1_SHA256, 32);
 #endif
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
 
@@ -3346,7 +3345,7 @@ static CK_RV test_rsa_gen_keys_id(void* args)
     if (ret == CKR_OK)
         ret = rsa_pss_test(session, priv, pub, CKM_SHA256, CKG_MGF1_SHA256, 32);
 #endif
-    
+
     funcList->C_DestroyObject(session, pub);
     funcList->C_DestroyObject(session, priv);
 
@@ -3752,7 +3751,7 @@ static CK_RV ecdh_test(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE privKey,
                                        "EC Derive Key zero public data length");
         params.ulPublicDataLen = pointLen;
     }
-    
+
     funcList->C_DestroyObject(session, secret);
 
     return ret;
@@ -3821,7 +3820,7 @@ static CK_RV test_ecc_create_key_fail(void* args)
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
     CK_RV ret = CKR_OK;
     CK_OBJECT_HANDLE obj = CK_INVALID_HANDLE;
-    CK_ATTRIBUTE ecc_p256_priv_key[] = {     
+    CK_ATTRIBUTE ecc_p256_priv_key[] = {
         { CKA_CLASS,             &privKeyClass,     sizeof(privKeyClass)      },
         { CKA_KEY_TYPE,          &eccKeyType,       sizeof(eccKeyType)        },
         { CKA_VERIFY,            &ckTrue,           sizeof(ckTrue)            },

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -560,7 +560,7 @@ static CK_RV test_slot(void* args)
     if (ret == CKR_OK) {
         for (i = 0; ret == CKR_OK && i < (int)count; i++) {
             ret = funcList->C_GetMechanismInfo(slot, list[i], &info);
-            CHECK_CKR(ret, "Get Mechansim info");
+            CHECK_CKR(ret, "Get mechanism info");
         }
     }
 
@@ -2146,7 +2146,7 @@ static CK_RV test_sign_verify(void* args)
         mech.mechanism = CKM_AES_CBC;
         ret = funcList->C_SignInit(session, &mech, key);
         CHECK_CKR_FAIL(ret, CKR_MECHANISM_INVALID,
-                                              "HMAC Sign Init wrong mechansim");
+                                              "HMAC Sign Init wrong mechanism");
         mech.mechanism = CKM_SHA256_HMAC;
     }
     if (ret == CKR_OK) {
@@ -2212,7 +2212,7 @@ static CK_RV test_sign_verify(void* args)
         mech.mechanism = CKM_AES_CBC;
         ret = funcList->C_VerifyInit(session, &mech, key);
         CHECK_CKR_FAIL(ret, CKR_MECHANISM_INVALID,
-                                            "HMAC Verify Init wrong mechansim");
+                                            "HMAC Verify Init wrong mechanism");
         mech.mechanism = CKM_SHA256_HMAC;
     }
     if (ret == CKR_OK) {
@@ -2668,7 +2668,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
     if (ret == CKR_OK) {
         ret = funcList->C_WrapKey(session, &mech, CK_INVALID_HANDLE, key,
                                                     wrappedKey, &wrappedKeyLen);
-        CHECK_CKR_FAIL(ret, CKR_OBJECT_HANDLE_INVALID,
+        CHECK_CKR_FAIL(ret, CKR_WRAPPING_KEY_HANDLE_INVALID,
                                         "Wrap Key invalid wrapping key handle");
     }
     if (ret == CKR_OK) {
@@ -2685,8 +2685,8 @@ static CK_RV test_wrap_unwrap_key(void* args)
     if (ret == CKR_OK) {
         ret = funcList->C_WrapKey(session, &mech, wrappingKey, key, wrappedKey,
                                                                 &wrappedKeyLen);
-        CHECK_CKR_FAIL(ret, CKR_MECHANISM_INVALID,
-                                            "Wrap Key mechansim not supported");
+        CHECK_CKR_FAIL(ret, CKR_KEY_NOT_WRAPPABLE,
+                                            "Wrap Key mechanism not supported");
     }
 
     if (ret == CKR_OK) {
@@ -2705,7 +2705,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
         ret = funcList->C_UnwrapKey(session, &mech, CK_INVALID_HANDLE,
                                        wrappedKey, wrappedKeyLen, tmpl, tmplCnt,
                                        &key);
-        CHECK_CKR_FAIL(ret, CKR_OBJECT_HANDLE_INVALID,
+        CHECK_CKR_FAIL(ret, CKR_UNWRAPPING_KEY_HANDLE_INVALID,
                                       "Unwrap Key invalid wrapping key handle");
     }
     if (ret == CKR_OK) {
@@ -2733,7 +2733,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
         ret = funcList->C_UnwrapKey(session, &mech, wrappingKey, wrappedKey,
                                             wrappedKeyLen, tmpl, tmplCnt, &key);
         CHECK_CKR_FAIL(ret, CKR_MECHANISM_INVALID,
-                                          "Unwrap Key mechansim not supported");
+                                          "Unwrap Key mechanism not supported");
     }
 
     return ret;

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -177,6 +177,8 @@ extern "C" {
 #define SESSION_COUNT_E                -8
 #define LOGGED_IN_E                    -9
 #define OBJ_COUNT_E                    -10
+#define OBJ_TYPE_E                     -11
+#define PARAM_E                        -12
 
 
 typedef struct WP11_Object WP11_Object;
@@ -261,6 +263,8 @@ int WP11_Object_SetSecretKey(WP11_Object* object, unsigned char** data,
                              CK_ULONG* len);
 int WP11_Object_SetClass(WP11_Object* object, CK_OBJECT_CLASS objClass);
 
+CK_OBJECT_CLASS WP11_Object_GetClass(WP11_Object* object);
+
 int WP11_Object_Find(WP11_Session* session, CK_OBJECT_HANDLE objHandle,
                      WP11_Object** object);
 int WP11_Object_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
@@ -270,9 +274,17 @@ int WP11_Object_SetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
 int WP11_Object_MatchAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
                           byte* data, CK_ULONG len);
 
+int WP11_Rsa_SerializeKey(WP11_Object* object, byte* output, word32* poutsz);
+
+int WP11_Rsa_ParsePrivKey(byte* data, word32 dataLen, WP11_Object* privKey);
+
+int WP11_Rsa_PrivKey2PubKey(WP11_Object* privKey, WP11_Object* pubKey, byte* workbuf, word32 worksz);
+
 int WP11_Rsa_GenerateKeyPair(WP11_Object* pub, WP11_Object* priv,
                              WP11_Slot* slot);
+
 word32 WP11_Rsa_KeyLen(WP11_Object* key);
+
 int WP11_Rsa_PublicEncrypt(unsigned char* in, word32 inLen, unsigned char* out,
                            word32* outLen, WP11_Object* pub, WP11_Slot* slot);
 int WP11_Rsa_PrivateDecrypt(unsigned char* in, word32 inLen, unsigned char* out,

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -386,7 +386,7 @@ int WP11_AesGcm_DecryptFinal(unsigned char* dec, word32* decSz,
                              WP11_Object* secret, WP11_Session* session);
 
 int WP11_Hmac_SigLen(WP11_Session* session);
-int WP11_Hmac_Init(CK_MECHANISM_TYPE mechansim, WP11_Object* secret,
+int WP11_Hmac_Init(CK_MECHANISM_TYPE mechanism, WP11_Object* secret,
                    WP11_Session* session);
 int WP11_Hmac_Sign(unsigned char* data, word32 dataLen, unsigned char* sig,
                    word32* sigLen, WP11_Session* session);

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -276,6 +276,8 @@ int WP11_Object_MatchAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
 
 int WP11_Rsa_SerializeKey(WP11_Object* object, byte* output, word32* poutsz);
 
+int WP11_Rsa_SerializeKeyPTPKC8(WP11_Object* object, byte* output, word32* poutsz);
+
 int WP11_Rsa_ParsePrivKey(byte* data, word32 dataLen, WP11_Object* privKey);
 
 int WP11_Rsa_PrivKey2PubKey(WP11_Object* privKey, WP11_Object* pubKey, byte* workbuf, word32 worksz);


### PR DESCRIPTION
Sean, David,

Here are the updates for the C_WrapKey/C_UnwrapKey addition that we (BRN) needs.  Please consider adding this.

As discussed on the call, we haven't added unit tests; however, Todd indicated that you would be willing.  We tested by implementation compatibility checks in a larger use case. All possible return codes haven't been tested.