### PR TITLE
Fixes: setting of label, init ecc object

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -3609,10 +3609,6 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE hSession,
         rv = AddObject(session, pub, pPublicKeyTemplate,
                                         ulPublicKeyAttributeCount, phPublicKey);
     }
-    if (rv == CKR_OK) {
-        rv = AddObject(session, priv, pPrivateKeyTemplate,
-                                      ulPrivateKeyAttributeCount, phPrivateKey);
-    }
 #ifdef WOLFPKCS11_KEYPAIR_GEN_COMMON_LABEL
     if (rv == CKR_OK) {
         CK_ULONG len;
@@ -3630,6 +3626,10 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE hSession,
         }
     }
 #endif
+    if (rv == CKR_OK) {
+        rv = AddObject(session, priv, pPrivateKeyTemplate,
+                                      ulPrivateKeyAttributeCount, phPrivateKey);
+    }
 
     if (rv != CKR_OK && pub != NULL)
         WP11_Object_Free(pub);

--- a/src/internal.c
+++ b/src/internal.c
@@ -1552,7 +1552,10 @@ static int wp11_Object_Decode_EccKey(WP11_Object* object)
                                     sizeof(object->iv));
         }
         if (ret == 0) {
-            /* Decode RSA private key. */
+            ret = wc_ecc_init(&object->data.ecKey);
+        }
+        if (ret == 0) {
+            /* Decode ECC private key. */
             ret = wc_EccPrivateKeyDecode(der, &idx, &object->data.ecKey, len);
             XMEMSET(der, 0, len);
         }
@@ -1560,7 +1563,7 @@ static int wp11_Object_Decode_EccKey(WP11_Object* object)
             XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
     else {
-        /* Decode RSA public key. */
+        /* Decode ECC public key. */
         ret = wc_EccPublicKeyDecode(object->keyData, &idx, &object->data.ecKey,
                                                             object->keyDataLen);
     }


### PR DESCRIPTION
Set the common label for the public key directly after creation rather than after private key has been added.
Initialize ecc object before decoding ECC private key. Fix comments.