### PR TITLE
Added compile-time defines for embedded builds

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -24,7 +24,11 @@
     #include <wolfpkcs11/config.h>
 #endif
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#else
+#include "user_settings.h"
+#endif
 #include <wolfssl/wolfcrypt/error-crypt.h>
 
 #include <wolfpkcs11/pkcs11.h>

--- a/src/internal.c
+++ b/src/internal.c
@@ -3391,13 +3391,13 @@ int WP11_Slot_SOLogin(WP11_Slot* slot, char* pin, int pinLen)
 {
     int ret = 0;
     WP11_Session* curr;
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     time_t now;
     time_t allowed;
 #endif
     int state;
 
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     if (wc_GetTime(&now, sizeof(now)) != 0)
         ret = PIN_INVALID_E;
 #endif
@@ -3411,7 +3411,7 @@ int WP11_Slot_SOLogin(WP11_Slot* slot, char* pin, int pinLen)
             ret = LOGGED_IN_E;
         }
     }
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     /* Check for too many fails and timeout. */
     if (ret == 0 && slot->token.soFailedLogin == WP11_MAX_LOGIN_FAILS_SO) {
         allowed = slot->token.soLastFailedLogin +
@@ -3438,7 +3438,7 @@ int WP11_Slot_SOLogin(WP11_Slot* slot, char* pin, int pinLen)
         WP11_Lock_LockRW(&slot->lock);
         /* PIN Failed - Update failure info. */
         if (ret == PIN_INVALID_E) {
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
             slot->token.soFailedLogin++;
             if (slot->token.soFailedLogin == WP11_MAX_LOGIN_FAILS_SO) {
                 slot->token.soLastFailedLogin = now;
@@ -3479,14 +3479,14 @@ int WP11_Slot_SOLogin(WP11_Slot* slot, char* pin, int pinLen)
 int WP11_Slot_UserLogin(WP11_Slot* slot, char* pin, int pinLen)
 {
     int ret = 0;
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     time_t now;
     time_t allowed;
 #endif
     int state;
     WP11_Token* token = &slot->token;
 
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     if (wc_GetTime(&now, sizeof(now)) != 0)
         ret = PIN_INVALID_E;
 #endif
@@ -3501,7 +3501,7 @@ int WP11_Slot_UserLogin(WP11_Slot* slot, char* pin, int pinLen)
             ret = LOGGED_IN_E;
         }
     }
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     /* Check for too many fails */
     if (ret == 0 && token->userFailedLogin == WP11_MAX_LOGIN_FAILS_USER) {
         allowed = token->userLastFailedLogin + token->userFailLoginTimeout;
@@ -3525,7 +3525,7 @@ int WP11_Slot_UserLogin(WP11_Slot* slot, char* pin, int pinLen)
         WP11_Lock_LockRW(&slot->lock);
         /* PIN Failed - Update failure info. */
         if (ret == PIN_INVALID_E) {
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
             token->userFailedLogin++;
             if (token->userFailedLogin == WP11_MAX_LOGIN_FAILS_USER) {
                 token->userLastFailedLogin = now;

--- a/src/internal.c
+++ b/src/internal.c
@@ -3420,8 +3420,9 @@ int WP11_Slot_SOLogin(WP11_Slot* slot, char* pin, int pinLen)
             slot->token.soFailedLogin = 0;
         else
             ret = PIN_INVALID_E;
-        slot->token.soFailedLogin = 0;
     }
+#else
+    slot->token.soFailedLogin = 0;
 #endif
     if (ret == 0) {
         for (curr = slot->session; curr != NULL; curr = curr->next) {
@@ -3509,8 +3510,9 @@ int WP11_Slot_UserLogin(WP11_Slot* slot, char* pin, int pinLen)
             token->userFailedLogin = 0;
         else
             ret = PIN_INVALID_E;
-        token->userFailedLogin = 0;
     }
+#else
+    token->userFailedLogin = 0;
 #endif
     WP11_Lock_UnlockRW(&slot->lock);
 

--- a/src/slot.c
+++ b/src/slot.c
@@ -134,7 +134,7 @@ static CK_TOKEN_INFO tokenInfoTemplate = {
  */
 CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 {
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     time_t now, expire;
     struct tm nowTM;
 #endif
@@ -153,7 +153,7 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
     pInfo->serialNumber[14] = ((slotID / 10) % 10) + '0';
     pInfo->serialNumber[15] = ((slotID /  1) % 10) + '0';
 
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     now = XTIME(0);
     XMEMSET(&nowTM, 0, sizeof(nowTM));
     if (XGMTIME(&now, &nowTM) != NULL) {
@@ -181,27 +181,27 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 #endif
 
     cnt = WP11_Slot_TokenFailedLogin(slot, WP11_LOGIN_SO);
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     expire = WP11_Slot_TokenFailedExpire(slot, WP11_LOGIN_SO);
 #endif
     if (cnt > 0)
         pInfo->flags |= CKF_SO_PIN_COUNT_LOW;
     if (cnt == WP11_MAX_LOGIN_FAILS_SO - 1)
         pInfo->flags |= CKF_SO_PIN_FINAL_TRY;
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     else if (cnt == WP11_MAX_LOGIN_FAILS_SO && now < expire)
         pInfo->flags |= CKF_SO_PIN_LOCKED;
 #endif
 
     cnt = WP11_Slot_TokenFailedLogin(slot, WP11_LOGIN_USER);
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     expire = WP11_Slot_TokenFailedExpire(slot, WP11_LOGIN_USER);
 #endif
     if (cnt > 0)
         pInfo->flags |= CKF_USER_PIN_COUNT_LOW;
     if (cnt == WP11_MAX_LOGIN_FAILS_USER - 1)
         pInfo->flags |= CKF_USER_PIN_FINAL_TRY;
-#ifndef NO_PKCS11_TIME
+#ifndef WOLFPKCS11_NO_TIME
     else if (cnt == WP11_MAX_LOGIN_FAILS_USER && now < expire)
         pInfo->flags |= CKF_USER_PIN_LOCKED;
 #endif

--- a/src/slot.c
+++ b/src/slot.c
@@ -134,8 +134,10 @@ static CK_TOKEN_INFO tokenInfoTemplate = {
  */
 CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
 {
+#ifndef NO_PKCS11_TIME
     time_t now, expire;
     struct tm nowTM;
+#endif
     WP11_Slot* slot;
     int cnt;
 
@@ -151,6 +153,7 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
     pInfo->serialNumber[14] = ((slotID / 10) % 10) + '0';
     pInfo->serialNumber[15] = ((slotID /  1) % 10) + '0';
 
+#ifndef NO_PKCS11_TIME
     now = XTIME(0);
     XMEMSET(&nowTM, 0, sizeof(nowTM));
     if (XGMTIME(&now, &nowTM) != NULL) {
@@ -173,24 +176,35 @@ CK_RV C_GetTokenInfo(CK_SLOT_ID slotID, CK_TOKEN_INFO_PTR pInfo)
         /* Set date to all zeros. */
         XMEMCPY(pInfo->utcTime, "00000000000000", 14);
     }
+#else
+    XMEMCPY(pInfo->utcTime, "00000000000000", 14);
+#endif
 
     cnt = WP11_Slot_TokenFailedLogin(slot, WP11_LOGIN_SO);
+#ifndef NO_PKCS11_TIME
     expire = WP11_Slot_TokenFailedExpire(slot, WP11_LOGIN_SO);
+#endif
     if (cnt > 0)
         pInfo->flags |= CKF_SO_PIN_COUNT_LOW;
     if (cnt == WP11_MAX_LOGIN_FAILS_SO - 1)
         pInfo->flags |= CKF_SO_PIN_FINAL_TRY;
+#ifndef NO_PKCS11_TIME
     else if (cnt == WP11_MAX_LOGIN_FAILS_SO && now < expire)
         pInfo->flags |= CKF_SO_PIN_LOCKED;
+#endif
 
     cnt = WP11_Slot_TokenFailedLogin(slot, WP11_LOGIN_USER);
+#ifndef NO_PKCS11_TIME
     expire = WP11_Slot_TokenFailedExpire(slot, WP11_LOGIN_USER);
+#endif
     if (cnt > 0)
         pInfo->flags |= CKF_USER_PIN_COUNT_LOW;
     if (cnt == WP11_MAX_LOGIN_FAILS_USER - 1)
         pInfo->flags |= CKF_USER_PIN_FINAL_TRY;
+#ifndef NO_PKCS11_TIME
     else if (cnt == WP11_MAX_LOGIN_FAILS_USER && now < expire)
         pInfo->flags |= CKF_USER_PIN_LOCKED;
+#endif
 
     if (WP11_Slot_IsTokenInitialized(slot))
         pInfo->flags |= CKF_TOKEN_INITIALIZED;

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -23,13 +23,20 @@
 #ifndef WOLFPKCS11_INTERNAL_H
 #define WOLFPKCS11_INTERNAL_H
 
+#ifndef WOLFSSL_USER_SETTINGS
 #include <wolfssl/options.h>
+#else
+#include "user_settings.h"
+#endif
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/wc_encrypt.h>
 
+#ifndef WOLFPKCS11_USER_SETTINGS
 #include <wolfpkcs11/options.h>
+#endif
+
 #include <wolfpkcs11/pkcs11.h>
 #include <wolfpkcs11/version.h>
 


### PR DESCRIPTION
- WOLFSSL_USER_SETTINGS to avoid including wolfssl/options.h
- WOLFPKCS11_USER_SETTINGS to avoid including wolfPKCS11/options.h
- NO_PKCS11_TIME to make wc_GetTime() optional (it disables bruteforce protections on token login)