### PR TITLE
Fixed argument passing in SetMPI/GetMPIData

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4722,7 +4722,7 @@ int WP11_Object_SetEcKey(WP11_Object* object, unsigned char** data,
             ret = EcSetParams(key, data[0], (int)len[0]);
         if (ret == 0 && data[1] != NULL) {
             key->type = ECC_PRIVATEKEY_ONLY;
-            ret = SetMPI(&key->k, data[1], (int)len[1]);
+            ret = SetMPI(key->k, data[1], (int)len[1]);
         }
         if (ret == 0 && data[2] != NULL) {
             if (key->type == ECC_PRIVATEKEY_ONLY)
@@ -5212,7 +5212,7 @@ static int EcObject_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
             if (noPriv)
                 *len = CK_UNAVAILABLE_INFORMATION;
             else
-                ret = GetMPIData(&object->data.ecKey.k, data, len);
+                ret = GetMPIData(object->data.ecKey.k, data, len);
             break;
         case CKA_EC_POINT:
             if (noPub)


### PR DESCRIPTION
When compiling with wolfboot, I spotted the following:

```
lib/wolfPKCS11/src/internal.c: In function 'WP11_Object_SetEcKey':
lib/wolfPKCS11/src/internal.c:4725:26: error: passing argument 1 of 'SetMPI' from incompatible pointer type [-Werror=incompatible-pointer-types]
 4725 |             ret = SetMPI(&key->k, data[1], (int)len[1]);
      |                          ^~~~~~~
      |                          |
      |                          mp_int (*)[1] {aka sp_int (*)[1]}
lib/wolfPKCS11/src/internal.c:4506:27: note: expected 'mp_int *' {aka 'sp_int *'} but argument is of type 'mp_int (*)[1]' {aka 'sp_int (*)[1]'}
 4506 | static int SetMPI(mp_int* mpi, unsigned char* data, int len)
      |                   ~~~~~~~~^~~
lib/wolfPKCS11/src/internal.c: In function 'EcObject_GetAttr':
lib/wolfPKCS11/src/internal.c:5215:34: error: passing argument 1 of 'GetMPIData' from incompatible pointer type [-Werror=incompatible-pointer-types]
 5215 |                 ret = GetMPIData(&object->data.ecKey.k, data, len);
      |                                  ^~~~~~~~~~~~~~~~~~~~~
      |                                  |
      |                                  mp_int (*)[1] {aka sp_int (*)[1]}
lib/wolfPKCS11/src/internal.c:4922:31: note: expected 'mp_int *' {aka 'sp_int *'} but argument is of type 'mp_int (*)[1]' {aka 'sp_int (*)[1]'}
 4922 | static int GetMPIData(mp_int* mpi, byte* data, CK_ULONG* len)
      |                       ~~~~~~~~^~~
cc1: all warnings being treated as errors
make: *** [Makefile:314: lib/wolfPKCS11/src/internal.o] Error 1
```
