### PR TITLE
Fixed NO_DH ifdef gate when freeing PKCS11 object

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -4456,7 +4456,7 @@ void WP11_Object_Free(WP11_Object* object)
     if (object->type == CKK_EC)
         wc_ecc_free(&object->data.ecKey);
 #endif
-#ifndef NO_RSA
+#ifndef NO_DH
     if (object->type == CKK_DH)
         wc_FreeDhKey(&object->data.dhKey.params);
 #endif


### PR DESCRIPTION
When compiling with RSA on but NO_DH, the following errors occur:
```
lib/wolfPKCS11/src/internal.c: In function 'WP11_Object_Free':
lib/wolfPKCS11/src/internal.c:4461:9: error: implicit declaration of function 'wc_FreeDhKey'; did you mean 'wc_FreeRsaKey'? [-Werror=implicit-function-declaration]
 4461 |         wc_FreeDhKey(&object->data.dhKey.params);
      |         ^~~~~~~~~~~~
      |         wc_FreeRsaKey
lib/wolfPKCS11/src/internal.c:4461:35: error: 'union <anonymous>' has no member named 'dhKey'
 4461 |         wc_FreeDhKey(&object->data.dhKey.params);
      |     
```

This patch guards the offending code with the right option `NO_DH` instead of `NO_RSA`.