### PR TITLE
Portability improvements for XREALLOC, XGETENV and pin hashing

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -695,7 +695,7 @@ int wolfPKCS11_Store_Open(int type, CK_ULONG id1, CK_ULONG id2, int read,
     void** store)
 {
     int ret = 0;
-#if defined(XGETENV) || !defined(WOLFPKCS11_TPM_STORE)
+#ifndef WOLFPKCS11_NO_ENV
     const char* str = NULL;
 #endif
 #ifdef WOLFPKCS11_TPM_STORE
@@ -715,7 +715,7 @@ int wolfPKCS11_Store_Open(int type, CK_ULONG id1, CK_ULONG id2, int read,
         type, id1, id2, read);
 #endif
 
-#ifdef XGETENV
+#ifndef WOLFPKCS11_NO_ENV
     str = XGETENV("WOLFPKCS11_NO_STORE");
     if (str != NULL) {
         return NOT_AVAILABLE_E;
@@ -764,7 +764,7 @@ int wolfPKCS11_Store_Open(int type, CK_ULONG id1, CK_ULONG id2, int read,
     #endif
 
 #else
-    #ifdef XGETENV
+    #ifndef WOLFPKCS11_NO_ENV
     str = XGETENV("WOLFPKCS11_TOKEN_PATH");
     #endif
     if (str == NULL) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -33,6 +33,7 @@
 #include <wolfssl/version.h>
 #include <wolfssl/wolfcrypt/pwdbased.h>
 #include <wolfssl/wolfcrypt/asn.h>
+#include <wolfssl/wolfcrypt/hash.h>
 #include <wolfssl/wolfcrypt/hmac.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/rsa.h>
@@ -3639,6 +3640,12 @@ static int HashPIN(char* pin, int pinLen, byte* seed, int seedLen, byte* hash,
     return wc_scrypt(hash, (byte*)pin, pinLen, seed, seedLen,
                                     WP11_HASH_PIN_COST, WP11_HASH_PIN_BLOCKSIZE,
                                     WP11_HASH_PIN_PARALLEL, hashLen);
+#elif !defined(NO_SHA256)
+    /* fallback to simple SHA2-256 hash of pin */
+    (void)seed;
+    (void)seedLen;
+    XMEMSET(hash, 0, hashLen);
+    return wc_Sha256Hash((const byte*)pin, pinLen, hash);
 #else
     (void)pin;
     (void)pinLen;

--- a/src/internal.c
+++ b/src/internal.c
@@ -8056,6 +8056,7 @@ int WP11_AesGcm_DecryptUpdate(unsigned char* enc, word32 encSz,
     unsigned char* newEnc;
     WP11_GcmParams* gcm = &session->params.gcm;
 
+#ifdef XREALLOC
     newEnc = (unsigned char*)XREALLOC(gcm->enc, gcm->encSz + encSz, NULL,
                                                        DYNAMIC_TYPE_TMP_BUFFER);
     if (newEnc == NULL)
@@ -8065,6 +8066,20 @@ int WP11_AesGcm_DecryptUpdate(unsigned char* enc, word32 encSz,
         XMEMCPY(gcm->enc + gcm->encSz, enc, encSz);
         gcm->encSz += encSz;
     }
+#else
+    newEnc = (unsigned char*)XMALLOC(gcm->encSz + encSz, NULL,
+                                                       DYNAMIC_TYPE_TMP_BUFFER);
+    if (newEnc == NULL)
+        ret = MEMORY_E;
+    if (ret == 0) {
+        if (gcm->enc != NULL)
+            XMEMCPY(newEnc, gcm->enc, gcm->encSz);
+        XFREE(gcm->enc, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        gcm->enc = newEnc;
+        XMEMCPY(gcm->enc + gcm->encSz, enc, encSz);
+        gcm->encSz += encSz;
+    }
+#endif /* !XREALLOC */
 
     return ret;
 }

--- a/tests/pkcs11mtt.c
+++ b/tests/pkcs11mtt.c
@@ -6499,7 +6499,7 @@ int pkcs11test_mtt(int argc, char* argv[])
     int i;
 
 #ifndef WOLFPKCS11_NO_ENV
-    setenv("WOLFPKCS11_NO_STORE", "1", 1);
+    XSETENV("WOLFPKCS11_NO_STORE", "1", 1);
 #endif
 
     argc--;

--- a/tests/pkcs11str.c
+++ b/tests/pkcs11str.c
@@ -923,8 +923,8 @@ int pkcs11test_str(int argc, char* argv[])
     int closeDl = 1;
 
 #ifndef WOLFPKCS11_NO_ENV
-    if (!getenv("WOLFPKCS11_TOKEN_PATH")) {
-        setenv("WOLFPKCS11_TOKEN_PATH", "./tests", 1);
+    if (!XGETENV("WOLFPKCS11_TOKEN_PATH")) {
+        XSETENV("WOLFPKCS11_TOKEN_PATH", "./tests", 1);
     }
 #endif
 

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -7791,8 +7791,10 @@ static CK_RV pkcs11_test(int slotId, int setPin, int onlySet, int closeDl)
         ret = pkcs11_lib_init();
 
     /* Do tests after library initialization but without SO PIN. */
-    if (ret == CKR_OK)
+    if (ret == CKR_OK) {
+        inited = 1;
         ret = run_tests(testFunc, testFuncCnt, onlySet, TEST_FLAG_INIT);
+    }
 
     if (ret == CKR_OK)
         ret = pkcs11_init_token();
@@ -7805,7 +7807,6 @@ static CK_RV pkcs11_test(int slotId, int setPin, int onlySet, int closeDl)
 
     /* Set user PIN. */
     if (ret == CKR_OK) {
-        inited = 1;
         if (setPin)
             ret = pkcs11_set_user_pin(slotId);
     }

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -7913,7 +7913,7 @@ int pkcs11test_test(int argc, char* argv[])
     int i;
 
 #ifndef WOLFPKCS11_NO_ENV
-    setenv("WOLFPKCS11_NO_STORE", "1", 1);
+    XSETENV("WOLFPKCS11_NO_STORE", "1", 1);
 #endif
 
     argc--;

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -24,19 +24,17 @@
 #define WOLFPKCS11_INTERNAL_H
 
 #ifndef WOLFSSL_USER_SETTINGS
-#include <wolfssl/options.h>
-#else
-#include "user_settings.h"
+    #include <wolfssl/options.h>
 #endif
+#include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/rsa.h>
 #include <wolfssl/wolfcrypt/ecc.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/wc_encrypt.h>
 
 #ifndef WOLFPKCS11_USER_SETTINGS
-#include <wolfpkcs11/options.h>
+    #include <wolfpkcs11/options.h>
 #endif
-
 #include <wolfpkcs11/pkcs11.h>
 #include <wolfpkcs11/version.h>
 

--- a/wolfpkcs11/pkcs11.h
+++ b/wolfpkcs11/pkcs11.h
@@ -28,6 +28,17 @@
 extern "C" {
 #endif
 
+/* Helpers for setenv/getenv */
+#if !defined(WOLFPKCS11_USER_ENV) && !defined(WOLFPKCS11_NO_ENV)
+    #include <stdlib.h>
+    #ifndef XSETENV
+        #define XSETENV setenv
+    #endif
+    #ifndef XGETENV
+        #define XGETENV getenv
+    #endif
+#endif
+
 #ifndef NULL_PTR
 #define NULL_PTR        0
 #endif


### PR DESCRIPTION
* Fix for portability case where `XREALLOC` is not available
* Add support for custom setenv/get env using `WOLFPKCS11_USER_ENV`.
* For embedded systems allow pin hashing using SHA2-256 vs script (which uses multiple MB of memory).
* Fix for final not being called after init in edge case pin failure.