### PR TITLE
Allow C_GetAttributeValue to yield length of fixed size attributes

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -246,13 +246,15 @@ static CK_RV CheckAttributes(CK_ATTRIBUTE* pTemplate, CK_ULONG ulCount, int set)
         if (attrType[j].type == ATTR_TYPE_ULONG) {
             if (attr->pValue == NULL && set)
                 return CKR_ATTRIBUTE_VALUE_INVALID;
-            if (attr->ulValueLen != sizeof(CK_ULONG))
+            if ((attr->pValue != NULL) &&
+                (attr->ulValueLen != sizeof(CK_ULONG)))
                 return CKR_BUFFER_TOO_SMALL;
         }
         else if (attrType[j].type == ATTR_TYPE_BOOL) {
             if (attr->pValue == NULL && set)
                 return CKR_ATTRIBUTE_VALUE_INVALID;
-            if (attr->ulValueLen != sizeof(CK_BBOOL))
+            if ((attr->pValue != NULL) && 
+                (attr->ulValueLen != sizeof(CK_BBOOL)))
                 return CKR_BUFFER_TOO_SMALL;
             if (set && *(CK_BBOOL*)attr->pValue != CK_TRUE &&
                                          *(CK_BBOOL*)attr->pValue != CK_FALSE) {
@@ -262,7 +264,8 @@ static CK_RV CheckAttributes(CK_ATTRIBUTE* pTemplate, CK_ULONG ulCount, int set)
         else if (attrType[j].type == ATTR_TYPE_DATE) {
             if (attr->pValue == NULL && set)
                 return CKR_ATTRIBUTE_VALUE_INVALID;
-            if (attr->ulValueLen != sizeof(CK_DATE))
+            if ((attr->pValue != NULL) && 
+                (attr->ulValueLen != sizeof(CK_DATE)))
                 return CKR_BUFFER_TOO_SMALL;
         }
         else if (attrType[j].type == ATTR_TYPE_DATA) {


### PR DESCRIPTION
Allow length retrieval even for fixed size attributes. 