### PR TITLE
Fixes for TPM based NV storage

### DIFF
--- a/wolfpkcs11/store.h
+++ b/wolfpkcs11/store.h
@@ -40,13 +40,14 @@
  * @param [in]   id1    Numeric identifier 1.
  * @param [in]   id2    Numeric identifier 2.
  * @param [in]   read   1 when opening for read and 0 for write.
+ * @param [in]   variableSz additional size needed for type (needed on write)
  * @param [out]  store  Return pointer to context data.
  * @return  0 on success.
  * @return  -4 when data not available.
  * @return  Other value to indicate failure.
  */
 int wolfPKCS11_Store_Open(int type, CK_ULONG id1, CK_ULONG id2, int read,
-    void** store);
+    int variableSz, void** store);
 
 /*
  * Closes access to location being read or written.


### PR DESCRIPTION
* Fix to use accurate NV sizes
* Add support for expanding NV (delete and recreate) if its not large enough on write.
* Fix to support using X.509 certificate store on TPM NV. Was not functional, since type was missing from wolfPKCS11_Store_GetMaxSize.
ZD 18462