### PR TITLE
Add option to disable `CKF_LOGIN_REQUIRED`

### DIFF
--- a/src/slot.c
+++ b/src/slot.c
@@ -106,7 +106,10 @@ static CK_TOKEN_INFO tokenInfoTemplate = {
     "wolfpkcs11",
     "wolfpkcs11",
     "0000000000000000", /* serialNumber */
-    CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_LOGIN_REQUIRED,
+#ifndef WOLFPKCS11_NO_LOGIN
+    CKF_LOGIN_REQUIRED |
+#endif
+    CKF_RNG | CKF_CLOCK_ON_TOKEN,
     WP11_SESSION_CNT_MAX, /* ulMaxSessionCount */
     CK_UNAVAILABLE_INFORMATION, /* ulSessionCount */
     WP11_SESSION_CNT_MAX, /* ulMaxRwSessionCount */

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -406,7 +406,11 @@ static CK_RV test_no_token_init(void* args)
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
     CK_RV ret;
     CK_TOKEN_INFO tokenInfo;
+#ifdef WOLFPKCS11_NO_LOGIN
+    CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN;
+#else
     CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_LOGIN_REQUIRED;
+#endif
     int flags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
 
     session = CK_INVALID_HANDLE;
@@ -590,8 +594,12 @@ static CK_RV test_token(void* args)
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
     CK_RV ret;
     CK_TOKEN_INFO tokenInfo;
+#ifdef WOLFPKCS11_NO_LOGIN
+    CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_TOKEN_INITIALIZED;
+#else
     CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_LOGIN_REQUIRED |
                         CKF_TOKEN_INITIALIZED;
+#endif
     unsigned char label[32];
     int flags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
 
@@ -891,8 +899,13 @@ static CK_RV test_login_logout(void* args)
     int roFlags = CKF_SERIAL_SESSION;
     CK_OBJECT_HANDLE roSession;
     CK_TOKEN_INFO tokenInfo;
+#ifdef WOLFPKCS11_NO_LOGIN
+    CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN |
+                        CKF_TOKEN_INITIALIZED | CKF_USER_PIN_INITIALIZED;
+#else
     CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_LOGIN_REQUIRED |
                         CKF_TOKEN_INITIALIZED | CKF_USER_PIN_INITIALIZED;
+#endif
 
     funcList->C_Logout(session);
 


### PR DESCRIPTION
There are times where we don't want login to be required. This is now possible via `WOLFPKCS11_NO_LOGIN`.