### PR TITLE
Object fixes

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -326,10 +326,10 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
     CK_KEY_TYPE type;
     CK_OBJECT_CLASS objClass;
 
+    (void) session;
+
     if (pTemplate == NULL)
         return CKR_ARGUMENTS_BAD;
-    if (!WP11_Session_IsRW(session))
-        return CKR_SESSION_READ_ONLY;
 
     rv = CheckAttributes(pTemplate, ulCount, 1);
     if (rv != CKR_OK)
@@ -678,6 +678,10 @@ static CK_RV CreateObject(WP11_Session* session, CK_ATTRIBUTE_PTR pTemplate,
         objectClass = *(CK_OBJECT_CLASS*)attr->pValue;
     }
 
+    if (((objectClass == CKO_PRIVATE_KEY) || (objectClass == CKO_SECRET_KEY)) &&
+        !WP11_Session_IsRW(session))
+        return CKR_SESSION_READ_ONLY;
+
     if (objectClass == CKO_CERTIFICATE) {
         FindAttributeType(pTemplate, ulCount, CKA_CERTIFICATE_TYPE, &attr);
         if (attr == NULL)
@@ -744,8 +748,6 @@ CK_RV C_CreateObject(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pTemplate,
         return CKR_SESSION_HANDLE_INVALID;
     if (pTemplate == NULL || phObject == NULL)
         return CKR_ARGUMENTS_BAD;
-    if (!WP11_Session_IsRW(session))
-        return CKR_SESSION_READ_ONLY;
 
     rv = CreateObject(session, pTemplate, ulCount, &object);
     if (rv != CKR_OK)

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -808,7 +808,7 @@ CK_RV C_CopyObject(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject,
      * object. Get the object type from original object and where to store
      * new object from template.
      */
-    ret = WP11_Object_Find(session, hObject, &obj);
+    ret = WP11_Object_Find(session, hObject, &obj, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
     keyType = WP11_Object_GetType(obj);
@@ -876,7 +876,7 @@ CK_RV C_DestroyObject(CK_SESSION_HANDLE hSession,
     if (!WP11_Session_IsRW(session))
         return CKR_SESSION_READ_ONLY;
 
-    ret = WP11_Object_Find(session, hObject, &obj);
+    ret = WP11_Object_Find(session, hObject, &obj, 0);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
@@ -915,7 +915,7 @@ CK_RV C_GetObjectSize(CK_SESSION_HANDLE hSession,
     if (pulSize == NULL)
         return CKR_ARGUMENTS_BAD;
 
-    ret = WP11_Object_Find(session, hObject, &obj);
+    ret = WP11_Object_Find(session, hObject, &obj, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
@@ -961,7 +961,7 @@ CK_RV C_GetAttributeValue(CK_SESSION_HANDLE hSession,
     if (pTemplate == NULL)
         return CKR_ARGUMENTS_BAD;
 
-    ret = WP11_Object_Find(session, hObject, &obj);
+    ret = WP11_Object_Find(session, hObject, &obj, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
@@ -1026,7 +1026,7 @@ CK_RV C_SetAttributeValue(CK_SESSION_HANDLE hSession,
     if (!WP11_Session_IsRW(session))
         return CKR_SESSION_READ_ONLY;
 
-    ret = WP11_Object_Find(session, hObject, &obj);
+    ret = WP11_Object_Find(session, hObject, &obj, 0);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
@@ -1180,7 +1180,7 @@ CK_RV C_EncryptInit(CK_SESSION_HANDLE hSession,
     if (pMechanism == NULL)
         return CKR_ARGUMENTS_BAD;
 
-    ret = WP11_Object_Find(session, hKey, &obj);
+    ret = WP11_Object_Find(session, hKey, &obj, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
@@ -1834,7 +1834,7 @@ CK_RV C_DecryptInit(CK_SESSION_HANDLE hSession,
     if (pMechanism == NULL)
         return CKR_ARGUMENTS_BAD;
 
-    ret = WP11_Object_Find(session, hKey, &obj);
+    ret = WP11_Object_Find(session, hKey, &obj, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
@@ -2587,7 +2587,7 @@ CK_RV C_DigestKey(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hKey)
     if (WP11_Session_Get(hSession, &session) != 0)
         return CKR_SESSION_HANDLE_INVALID;
 
-    ret = WP11_Object_Find(session, hKey, &obj);
+    ret = WP11_Object_Find(session, hKey, &obj, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
@@ -2668,7 +2668,7 @@ CK_RV C_SignInit(CK_SESSION_HANDLE hSession, CK_MECHANISM_PTR pMechanism,
     if (pMechanism == NULL)
         return CKR_ARGUMENTS_BAD;
 
-    ret = WP11_Object_Find(session, hKey, &obj);
+    ret = WP11_Object_Find(session, hKey, &obj, 1);
 #ifdef WOLFSSL_MAXQ10XX_CRYPTO
     if ((ret != 0) && (hKey == 0) && (pMechanism->mechanism == CKM_ECDSA)) {
         if (pMechanism->pParameter != NULL || pMechanism->ulParameterLen != 0) {
@@ -3139,7 +3139,7 @@ CK_RV C_SignRecoverInit(CK_SESSION_HANDLE hSession,
     if (pMechanism == NULL)
         return CKR_ARGUMENTS_BAD;
 
-    ret = WP11_Object_Find(session, hKey, &obj);
+    ret = WP11_Object_Find(session, hKey, &obj, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
@@ -3216,7 +3216,7 @@ CK_RV C_VerifyInit(CK_SESSION_HANDLE hSession,
     if (pMechanism == NULL)
         return CKR_ARGUMENTS_BAD;
 
-    ret = WP11_Object_Find(session, hKey, &obj);
+    ret = WP11_Object_Find(session, hKey, &obj, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
@@ -3614,7 +3614,7 @@ CK_RV C_VerifyRecoverInit(CK_SESSION_HANDLE hSession,
     if (pMechanism == NULL)
         return CKR_ARGUMENTS_BAD;
 
-    ret = WP11_Object_Find(session, hKey, &obj);
+    ret = WP11_Object_Find(session, hKey, &obj, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
@@ -3921,7 +3921,7 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE hSession,
                         CK_OBJECT_HANDLE_PTR phPrivateKey)
 {
     int ret;
-    CK_RV rv;
+    CK_RV rv = CKR_OK;
     WP11_Session* session = NULL;
     WP11_Object* pub = NULL;
     WP11_Object* priv = NULL;
@@ -4096,11 +4096,11 @@ CK_RV C_WrapKey(CK_SESSION_HANDLE hSession,
     if (! WP11_Session_IsRW(session))
         return CKR_SESSION_READ_ONLY;
 
-    ret = WP11_Object_Find(session, hKey, &key);
+    ret = WP11_Object_Find(session, hKey, &key, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
-    ret = WP11_Object_Find(session, hWrappingKey, &wrappingKey);
+    ret = WP11_Object_Find(session, hWrappingKey, &wrappingKey, 1);
     if (ret != 0)
         return CKR_WRAPPING_KEY_HANDLE_INVALID;
 
@@ -4228,7 +4228,7 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
 
     *phKey = CK_INVALID_HANDLE;
 
-    ret = WP11_Object_Find(session, hUnwrappingKey, &unwrappingKey);
+    ret = WP11_Object_Find(session, hUnwrappingKey, &unwrappingKey, 1);
     if (ret != 0)
         return CKR_UNWRAPPING_KEY_HANDLE_INVALID;
 
@@ -4378,7 +4378,7 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
                   CK_OBJECT_HANDLE_PTR phKey)
 {
     int ret;
-    CK_RV rv;
+    CK_RV rv = CKR_OK;
     WP11_Session* session;
     WP11_Object* obj = NULL;
 #if defined(HAVE_ECC) || !defined(NO_DH)
@@ -4396,7 +4396,7 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
     if (pMechanism == NULL || pTemplate == NULL || phKey == NULL)
         return CKR_ARGUMENTS_BAD;
 
-    ret = WP11_Object_Find(session, hBaseKey, &obj);
+    ret = WP11_Object_Find(session, hBaseKey, &obj, 1);
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 

--- a/tests/pkcs11mtt.c
+++ b/tests/pkcs11mtt.c
@@ -150,7 +150,7 @@ static CK_RV test_op_state(void* args)
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
     CK_RV ret;
     byte data;
-    CK_ULONG len;
+    CK_ULONG len = 0;
 
     ret = funcList->C_GetOperationState(CK_INVALID_HANDLE, NULL, &len);
     CHECK_CKR_FAIL(ret, CKR_SESSION_HANDLE_INVALID,

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -286,7 +286,7 @@ int WP11_Object_SetClass(WP11_Object* object, CK_OBJECT_CLASS objClass);
 CK_OBJECT_CLASS WP11_Object_GetClass(WP11_Object* object);
 
 int WP11_Object_Find(WP11_Session* session, CK_OBJECT_HANDLE objHandle,
-                     WP11_Object** object);
+                     WP11_Object** object, byte allSessions);
 int WP11_Object_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
                         CK_ULONG* len);
 int WP11_Object_SetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,


### PR DESCRIPTION
This fixes the following:

* Public objects should be writeable in a read-only connection.
* Session objects should be readable by other sessions for the same application.
* Some minor Valgrind / Cppcheck hits
* When an object was not found for a session, it would return the last object in the list for the session with the error