### PR TITLE
Crypto fixes

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1512,7 +1512,8 @@ CK_RV C_Encrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData,
                 return CKR_OPERATION_NOT_INITIALIZED;
             }
 
-            encDataLen = (word32)ulDataLen;
+            /* PKCS#5 pad makes the output a multiple of 16 */
+            encDataLen = (word32)((ulDataLen + 15) / 16) * 16;
             if (pEncryptedData == NULL) {
                 *pulEncryptedDataLen = encDataLen;
                 return CKR_OK;

--- a/src/internal.c
+++ b/src/internal.c
@@ -8190,7 +8190,13 @@ int WP11_EC_Derive(unsigned char* point, word32 pointLen, unsigned char* key,
 
     ret = wc_ecc_init_ex(&pubKey, NULL, priv->slot->devId);
     if (ret == 0) {
-        ret = wc_ecc_import_x963(point, pointLen, &pubKey);
+        if (priv->data.ecKey.dp) {
+            ret = wc_ecc_import_x963_ex(point, pointLen, &pubKey,
+                                        priv->data.ecKey.dp->id);
+        }
+        else {
+            ret = wc_ecc_import_x963(point, pointLen, &pubKey);
+        }
     }
 #if defined(ECC_TIMING_RESISTANT) && (!defined(HAVE_FIPS) || \
     (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2)))

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -6438,6 +6438,43 @@ static CK_RV test_aes_cbc_gen_key_id(void* args)
     return ret;
 }
 
+static CK_RV test_aes_cbc_pad_len_test(void* args)
+{
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_RV ret;
+    CK_OBJECT_HANDLE key;
+    CK_MECHANISM mech;
+    CK_ULONG plainSz, encSz, ivSz;
+    byte plain[15], iv[16];
+
+    memset(plain, 9, sizeof(plain));
+    plainSz = sizeof(plain);
+    encSz = plainSz;
+    ivSz = sizeof(iv);
+
+    mech.mechanism      = CKM_AES_CBC_PAD;
+    mech.ulParameterLen = ivSz;
+    mech.pParameter     = iv;
+
+    ret = get_aes_128_key(session, NULL, 0, &key);
+    CHECK_CKR(ret, "Getting AES key");
+    if (ret == CKR_OK) {
+        ret = funcList->C_EncryptInit(session, &mech, key);
+        CHECK_CKR(ret, "AES-CBC Pad Encrypt Init");
+    }
+    if (ret == CKR_OK) {
+        encSz = 0;
+        ret = funcList->C_Encrypt(session, plain, plainSz, NULL, &encSz);
+        CHECK_CKR(ret, "AES-CBC Pad Encrypt no enc");
+    }
+    /* CKM_AES_CBC_PAD length is rounded up to the nearest multiple of 16 */
+    if (ret == CKR_OK && encSz != 16) {
+        ret = -1;
+        CHECK_CKR(ret, "AES-CBC Pad Encrypt encrypted length");
+    }
+    return ret;
+}
+
 static CK_RV test_aes_cbc_pad_encdec(CK_SESSION_HANDLE session,
                                      unsigned char* exp, CK_OBJECT_HANDLE key)
 {
@@ -9292,6 +9329,7 @@ static TEST_FUNC testFunc[] = {
 #endif
 #ifndef NO_AES
 #ifdef HAVE_AES_CBC
+    PKCS11TEST_FUNC_SESS_DECL(test_aes_cbc_pad_len_test),
     PKCS11TEST_FUNC_SESS_DECL(test_aes_cbc_fixed_key),
     PKCS11TEST_FUNC_SESS_DECL(test_aes_cbc_fail),
     PKCS11TEST_FUNC_SESS_DECL(test_aes_cbc_gen_key),

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -5237,6 +5237,138 @@ static CK_RV ecdsa_test(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE privKey,
     return ret;
 }
 
+/* Tests for error occuring when private and public curves mismatch. */
+/* Crashes with TPM test right now. */
+#ifndef WOLFPKCS11_TPM
+static CK_RV test_ecc_curve(void *args)
+{
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_RV ret;
+    CK_OBJECT_HANDLE hAlicePubKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hAlicePrivKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hBobPubKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hBobPrivKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hSharedSecret = CK_INVALID_HANDLE;
+    CK_MECHANISM mechanismGen = { CKM_EC_KEY_PAIR_GEN, NULL_PTR, 0 };
+    CK_BYTE ecParams_secp256r1[] =
+        { 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07 };
+
+    CK_ATTRIBUTE alicePubKeyTemplate[] = {
+        {CKA_EC_PARAMS, ecParams_secp256r1, sizeof(ecParams_secp256r1)},
+        {CKA_TOKEN, &ckFalse, sizeof(ckFalse)},
+        {CKA_VERIFY, &ckTrue, sizeof(ckTrue)},
+        {CKA_ENCRYPT, &ckFalse, sizeof(ckFalse)},
+        {CKA_WRAP, &ckFalse, sizeof(ckFalse)},
+        {CKA_LABEL, (CK_UTF8CHAR_PTR)"Alice_PublicKey",
+            strlen("Alice_PublicKey")}
+    };
+    CK_ULONG ulAlicePubKeyAttrCount =
+        sizeof(alicePubKeyTemplate) / sizeof(CK_ATTRIBUTE);
+    CK_ATTRIBUTE alicePrivKeyTemplate[] = {
+        {CKA_TOKEN, &ckFalse, sizeof(ckFalse)},
+        {CKA_PRIVATE, &ckTrue, sizeof(ckTrue)},
+        {CKA_SENSITIVE, &ckTrue, sizeof(ckTrue)},
+        {CKA_EXTRACTABLE, &ckFalse, sizeof(ckFalse)},
+        {CKA_SIGN, &ckFalse, sizeof(ckFalse)},
+        {CKA_DECRYPT, &ckFalse, sizeof(ckFalse)},
+        {CKA_DERIVE, &ckTrue, sizeof(ckTrue)},
+        {CKA_LABEL, (CK_UTF8CHAR_PTR)"Alice_PrivateKey",
+            strlen("Alice_PrivateKey")}
+    };
+    CK_ULONG ulAlicePrivKeyAttrCount =
+        sizeof(alicePrivKeyTemplate) / sizeof(CK_ATTRIBUTE);
+
+    CK_ATTRIBUTE bobPubKeyTemplate[] = {
+        {CKA_EC_PARAMS, ecParams_secp256r1, sizeof(ecParams_secp256r1)},
+        {CKA_TOKEN, &ckFalse, sizeof(ckFalse)},
+        {CKA_VERIFY, &ckTrue, sizeof(ckTrue)},
+        {CKA_LABEL, (CK_UTF8CHAR_PTR)"Bob_PublicKey", strlen("Bob_PublicKey")}
+    };
+    CK_ULONG ulBobPubKeyAttrCount =
+        sizeof(bobPubKeyTemplate) / sizeof(CK_ATTRIBUTE);
+    CK_ATTRIBUTE bobPrivKeyTemplate[] = {
+        {CKA_TOKEN, &ckFalse, sizeof(ckFalse)},
+        {CKA_PRIVATE, &ckTrue, sizeof(ckTrue)},
+        {CKA_SENSITIVE, &ckTrue, sizeof(ckTrue)},
+        {CKA_EXTRACTABLE, &ckFalse, sizeof(ckFalse)},
+        {CKA_DERIVE, &ckTrue, sizeof(ckTrue)},
+        {CKA_LABEL, (CK_UTF8CHAR_PTR)"Bob_PrivateKey", strlen("Bob_PrivateKey")}
+    };
+    CK_ULONG ulBobPrivKeyAttrCount =
+        sizeof(bobPrivKeyTemplate) / sizeof(CK_ATTRIBUTE);
+    CK_ATTRIBUTE bobEcPointAttr = { CKA_EC_POINT, NULL_PTR, 0 };
+
+    CK_ECDH1_DERIVE_PARAMS ecdhParams;
+    CK_MECHANISM mechanismECDH =
+        { CKM_ECDH1_DERIVE, &ecdhParams, sizeof(ecdhParams) };
+
+    CK_OBJECT_CLASS secretClass = CKO_SECRET_KEY;
+    CK_ATTRIBUTE sharedSecretTemplate[] = {
+        {CKA_CLASS, &secretClass, sizeof(secretClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_TOKEN, &ckFalse, sizeof(ckFalse)},
+        {CKA_PRIVATE, &ckTrue, sizeof(ckTrue)},
+        {CKA_SENSITIVE, &ckTrue, sizeof(ckTrue)},
+        {CKA_EXTRACTABLE, &ckFalse, sizeof(ckFalse)},
+        {CKA_DERIVE, &ckTrue, sizeof(ckTrue)},
+        {CKA_LABEL, (CK_UTF8CHAR_PTR)"ECDH_SharedSecret",
+            strlen("ECDH_SharedSecret")}
+    };
+    CK_ULONG ulSharedSecretAttrCount =
+        sizeof(sharedSecretTemplate) / sizeof(CK_ATTRIBUTE);
+
+    ret = funcList->C_GenerateKeyPair(session, &mechanismGen,
+                                alicePubKeyTemplate, ulAlicePubKeyAttrCount,
+                                alicePrivKeyTemplate, ulAlicePrivKeyAttrCount,
+                                &hAlicePubKey, &hAlicePrivKey);
+
+    CHECK_CKR(ret, "Alice key gen failure");
+    if (ret == CKR_OK) {
+        ret = funcList->C_GenerateKeyPair(session, &mechanismGen,
+            bobPubKeyTemplate, ulBobPubKeyAttrCount,
+            bobPrivKeyTemplate, ulBobPrivKeyAttrCount,
+            &hBobPubKey, &hBobPrivKey);
+        CHECK_CKR(ret, "Bob key gen failure");
+    }
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_GetAttributeValue(session, hBobPubKey,
+            &bobEcPointAttr, 1);
+        CHECK_CKR(ret, "C_GetAttributeValue (Bob EC Point size)");
+    }
+
+    if (ret == CKR_OK) {
+        bobEcPointAttr.pValue = XMALLOC(bobEcPointAttr.ulValueLen, NULL,
+                                        DYNAMIC_TYPE_TMP_BUFFER);
+        if (bobEcPointAttr.pValue == NULL)
+            ret = CKR_DEVICE_MEMORY;
+        CHECK_CKR(ret, "Allocate Bob's EC point");
+    }
+
+    if (ret == CKR_OK){
+        ret = funcList->C_GetAttributeValue(session, hBobPubKey,
+            &bobEcPointAttr, 1);
+        CHECK_CKR(ret, "C_GetAttributeValue (Bob EC Point value)");
+    }
+
+    if (ret == CKR_OK) {
+        ecdhParams.kdf = CKD_NULL;
+        ecdhParams.ulSharedDataLen = 0; /* No shared data in this step */
+        ecdhParams.pSharedData = NULL_PTR;
+        ecdhParams.ulPublicDataLen = bobEcPointAttr.ulValueLen;
+        ecdhParams.pPublicData = (CK_BYTE_PTR)bobEcPointAttr.pValue;
+
+        /* Derive the key using Alice's Private Key and Bob's Public Data */
+        ret = funcList->C_DeriveKey(session, &mechanismECDH, hAlicePrivKey,
+            sharedSecretTemplate, ulSharedSecretAttrCount,
+            &hSharedSecret);
+        CHECK_CKR(ret, "C_DeriveKey (ECDH1)");
+    }
+
+    return ret;
+}
+#endif
+
 static CK_RV test_ecc_create_key_fail(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
@@ -9314,6 +9446,9 @@ static TEST_FUNC testFunc[] = {
 #endif
 #endif
 #ifdef HAVE_ECC
+#ifndef WOLFPKCS11_TPM
+    PKCS11TEST_FUNC_SESS_DECL(test_ecc_curve),
+#endif
     PKCS11TEST_FUNC_SESS_DECL(test_ecc_create_key_fail),
     PKCS11TEST_FUNC_SESS_DECL(test_ecc_fixed_keys_ecdh),
     PKCS11TEST_FUNC_SESS_DECL(test_ecc_fixed_keys_ecdsa),


### PR DESCRIPTION
Fixes the following things:

* Fix key wipe in `WP11_Object_SetEcKey`
* Fix AES CBC padding calculation
* Fix ECC derive key curve error