### PR TITLE
Fix boolean attributes and permissions

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -301,6 +301,169 @@ static CK_RV CheckAttributes(CK_ATTRIBUTE* pTemplate, CK_ULONG ulCount, int set)
     return CKR_OK;
 }
 
+static CK_RV SetInitialStates(WP11_Object* key)
+{
+    CK_RV rv;
+    CK_BBOOL trueVar = CK_TRUE;
+    CK_BBOOL getVar;
+    CK_ULONG getVarLen = sizeof(CK_BBOOL);
+
+    rv = WP11_Object_GetAttr(key, CKA_SENSITIVE, &getVar, &getVarLen);
+    if ((rv == CKR_OK) && (getVar == CK_TRUE)) {
+        rv = WP11_Object_SetAttr(key, CKA_ALWAYS_SENSITIVE, &trueVar,
+                                    sizeof(CK_BBOOL));
+    }
+    if (rv == CKR_OK) {
+        rv = WP11_Object_GetAttr(key, CKA_EXTRACTABLE, &getVar, &getVarLen);
+        if ((rv == CKR_OK) && (getVar == CK_FALSE)) {
+            rv = WP11_Object_SetAttr(key, CKA_NEVER_EXTRACTABLE, &trueVar,
+                                    sizeof(CK_BBOOL));
+        }
+    }
+    return rv;
+}
+
+static CK_RV TemplateHasAttribute(CK_ATTRIBUTE_TYPE type,
+        CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
+{
+    for (CK_ULONG i = 0; i < ulCount; i++) {
+        if (type == pTemplate[i].type)
+            return CKR_OK;
+    }
+
+    return CKR_ATTRIBUTE_TYPE_INVALID;
+}
+
+static CK_RV SetIfNotFound(WP11_Object* obj, CK_ATTRIBUTE_TYPE type,
+                           CK_BBOOL state, CK_ATTRIBUTE_PTR pTemplate,
+                           CK_ULONG ulCount)
+{
+    CK_RV ret;
+
+    /* False states are always default */
+    if (state == CK_FALSE) {
+        return CKR_OK;
+    }
+
+    if (TemplateHasAttribute(type, pTemplate, ulCount) == CKR_OK) {
+        return CKR_OK;
+    }
+
+    ret = WP11_Object_SetAttr(obj, type, &state, sizeof(CK_BBOOL));
+    return ret;
+}
+
+static CK_RV SetAttributeDefaults(WP11_Object* obj, CK_OBJECT_CLASS keyType,
+                                  CK_ATTRIBUTE_PTR pTemplate,
+                                  CK_ULONG ulCount)
+{
+    CK_RV ret = CKR_OK;
+    CK_BBOOL trueVal = CK_TRUE;
+    CK_BBOOL falseVal = CK_FALSE;
+    CK_BBOOL encrypt = CK_TRUE;
+    CK_BBOOL recover = CK_TRUE;
+    CK_BBOOL wrap = CK_TRUE;
+    CK_BBOOL derive = (keyType == CKO_PUBLIC_KEY ? CK_FALSE : CK_TRUE);
+    CK_BBOOL verify = CK_TRUE;
+    CK_BBOOL sign = CK_FALSE;
+
+    CK_KEY_TYPE type = WP11_Object_GetType(obj);
+
+    switch (type) {
+        /* If we implement DSA
+        case CKK_DSA:
+            encrypt = CK_FALSE;
+            recover = CK_FALSE;
+            wrap = CK_FALSE;
+            sign = CK_TRUE;
+            derive = CK_FALSE;
+            break;
+        */
+        case CKK_DH:
+            verify = CK_FALSE;
+            derive = CK_TRUE;
+            encrypt = CK_FALSE;
+            recover = CK_FALSE;
+            wrap = CK_FALSE;
+            break;
+        case CKK_EC:
+            derive = CK_FALSE;
+            verify = CK_FALSE;
+            encrypt = CK_FALSE;
+            recover = CK_FALSE;
+            wrap = CK_FALSE;
+            sign = CK_TRUE;
+            break;
+    }
+
+    /* Defaults if not set */
+    switch (keyType) {
+        case CKO_PUBLIC_KEY:
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_ENCRYPT, encrypt, pTemplate,
+                                    ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_VERIFY, verify, pTemplate,
+                                    ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_VERIFY_RECOVER, recover, pTemplate,
+                                    ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_WRAP, wrap, pTemplate, ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_DERIVE, derive, pTemplate,
+                                    ulCount);
+            break;
+        case CKO_SECRET_KEY:
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_EXTRACTABLE, trueVal, pTemplate,
+                                    ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_ENCRYPT, trueVal, pTemplate,
+                                    ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_DECRYPT, trueVal, pTemplate,
+                                    ulCount);
+            /* CKA_SIGN / CKA_VERIFY default false */
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_WRAP, trueVal, pTemplate, ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_UNWRAP, trueVal, pTemplate,
+                                    ulCount);
+            break;
+        case CKO_PRIVATE_KEY:
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_EXTRACTABLE, trueVal, pTemplate,
+                                    ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_DECRYPT, encrypt, pTemplate,
+                                    ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_SIGN, sign, pTemplate, ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_SIGN_RECOVER, recover, pTemplate,
+                                    ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_UNWRAP, wrap, pTemplate, ulCount);
+            if (ret == CKR_OK)
+                ret = SetIfNotFound(obj, CKA_DERIVE, derive, pTemplate,
+                                    ulCount);
+            break;
+    }
+
+    /* Next two are forced attributes */
+    if (ret == CKR_OK &&
+        (keyType == CKO_PRIVATE_KEY || keyType == CKO_SECRET_KEY)) {
+            ret = WP11_Object_SetAttr(obj, CKA_ALWAYS_SENSITIVE, &falseVal,
+                                      sizeof(CK_BBOOL));
+            if (ret == CKR_OK)
+                ret = WP11_Object_SetAttr(obj, CKA_NEVER_EXTRACTABLE, &falseVal,
+                                          sizeof(CK_BBOOL));
+    }
+
+    return ret;
+}
+
 /**
  * Set the values of the attributes into the object.
  *
@@ -332,6 +495,8 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
     int cnt;
     CK_KEY_TYPE type;
     CK_OBJECT_CLASS objClass;
+    CK_BBOOL getVar;
+    CK_ULONG getVarLen = 1;
 
     if (pTemplate == NULL)
         return CKR_ARGUMENTS_BAD;
@@ -441,6 +606,15 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
     /* Set remaining attributes - key specific attributes ignored. */
     for (i = 0; i < (int)ulCount; i++) {
         attr = &pTemplate[i];
+        /* Cannot change sensitive from true to false */
+        if (attr->type == CKA_SENSITIVE) {
+            rv = WP11_Object_GetAttr(obj, CKA_SENSITIVE, &getVar, &getVarLen);
+            if (rv != CKR_OK)
+                return rv;
+
+            if ((getVar == CK_TRUE) && (*(CK_BBOOL*)attr->pValue == CK_FALSE))
+                return CKR_ATTRIBUTE_READ_ONLY;
+        }
         ret = WP11_Object_SetAttr(obj, attr->type, (byte*)attr->pValue,
                                                               attr->ulValueLen);
         if (ret == BAD_FUNC_ARG)
@@ -486,6 +660,22 @@ static CK_RV NewObject(WP11_Session* session, CK_KEY_TYPE keyType,
         return CKR_FUNCTION_FAILED;
 
     rv = SetAttributeValue(session, obj, pTemplate, ulCount);
+    if (rv != CKR_OK) {
+        WP11_Object_Free(obj);
+        return rv;
+    }
+
+    switch(keyClass) {
+        case CKO_PRIVATE_KEY:
+        case CKO_SECRET_KEY:
+        case CKO_PUBLIC_KEY:
+            rv = SetAttributeDefaults(obj, keyClass, pTemplate, ulCount);
+            break;
+        default:
+            /* For other types, such as potential CKO_DATA, not needed */
+            rv = CKR_OK;
+            break;
+    }
     if (rv != CKR_OK) {
         WP11_Object_Free(obj);
         return rv;
@@ -999,11 +1189,13 @@ CK_RV C_GetAttributeValue(CK_SESSION_HANDLE hSession,
             return CKR_BUFFER_TOO_SMALL;
         else if (ret == NOT_AVAILABLE_E)
             return CK_UNAVAILABLE_INFORMATION;
+        else if (ret == CKR_ATTRIBUTE_SENSITIVE)
+            rv = ret;
         else if (ret != 0)
             return CKR_FUNCTION_FAILED;
     }
 
-    return CKR_OK;
+    return rv;
 }
 
 /**
@@ -5017,6 +5209,10 @@ CK_RV C_GenerateKey(CK_SESSION_HANDLE hSession,
             return CKR_MECHANISM_INVALID;
     }
 
+    if (rv == CKR_OK) {
+        rv = SetInitialStates(key);
+    }
+
     return rv;
 }
 
@@ -5180,6 +5376,14 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE hSession,
     if (rv == CKR_OK) {
         rv = AddObject(session, priv, pPrivateKeyTemplate,
                                       ulPrivateKeyAttributeCount, phPrivateKey);
+    }
+
+    if (pub != NULL && rv == CKR_OK) {
+        rv = SetInitialStates(pub);
+    }
+
+    if (priv != NULL && rv == CKR_OK) {
+        rv = SetInitialStates(priv);
     }
 
     if (rv != CKR_OK && pub != NULL)
@@ -5738,6 +5942,10 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
                 }
             }
         }
+    }
+
+    if (rv == CKR_OK) {
+        rv = SetInitialStates(obj);
     }
 
     if (derivedKey != NULL) {

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1757,7 +1757,8 @@ CK_RV C_Encrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData,
             }
 
             /* PKCS#5 pad makes the output a multiple of 16 */
-            encDataLen = (word32)((ulDataLen + 15) / 16) * 16;
+            encDataLen = (word32)((ulDataLen + WC_AES_BLOCK_SIZE - 1) /
+                        WC_AES_BLOCK_SIZE) * WC_AES_BLOCK_SIZE;
             if (pEncryptedData == NULL) {
                 *pulEncryptedDataLen = encDataLen;
                 return CKR_OK;

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -483,7 +483,8 @@ static CK_RV SetAttributeDefaults(WP11_Object* obj, CK_OBJECT_CLASS keyType,
  *          CKR_OK on success.
  */
 static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
-                               CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount)
+                               CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
+                               CK_BBOOL newObject)
 {
     int ret = 0;
     CK_RV rv;
@@ -493,6 +494,7 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
     CK_ULONG len[OBJ_MAX_PARAMS] = { 0, };
     CK_ATTRIBUTE_TYPE* attrs = NULL;
     int cnt;
+    CK_BBOOL attrsFound = 0;
     CK_KEY_TYPE type;
     CK_OBJECT_CLASS objClass;
     CK_BBOOL getVar;
@@ -506,6 +508,7 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
     rv = CheckAttributes(pTemplate, ulCount, 1);
     if (rv != CKR_OK)
         return rv;
+
 
     type = WP11_Object_GetType(obj);
     objClass = WP11_Object_GetClass(obj);
@@ -553,6 +556,7 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
     for (i = 0; i < cnt; i++) {
         for (j = 0; j < (int)ulCount; j++) {
             if (attrs[i] == pTemplate[j].type) {
+                attrsFound = 1;
                 data[i] = (unsigned char*)pTemplate[j].pValue;
                 if (data[i] == NULL)
                     return CKR_ATTRIBUTE_VALUE_INVALID;
@@ -562,46 +566,48 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
         }
     }
 
-    if (objClass == CKO_CERTIFICATE) {
-        ret = WP11_Object_SetCert(obj, data, len);
-    }
-    else {
-        /* Set the value and length of key specific attributes
-        * Old key data is cleared.
-        */
-        switch (type) {
-    #ifndef NO_RSA
-            case CKK_RSA:
-                ret = WP11_Object_SetRsaKey(obj, data, len);
-                break;
-    #endif
-    #ifdef HAVE_ECC
-            case CKK_EC:
-                ret = WP11_Object_SetEcKey(obj, data, len);
-                break;
-    #endif
-    #ifndef NO_DH
-            case CKK_DH:
-                ret = WP11_Object_SetDhKey(obj, data, len);
-                break;
-    #endif
-    #ifdef WOLFPKCS11_HKDF
-            case CKK_HKDF:
-    #endif
-    #ifndef NO_AES
-            case CKK_AES:
-    #endif
-            case CKK_GENERIC_SECRET:
-                ret = WP11_Object_SetSecretKey(obj, data, len);
-                break;
-            default:
-                break;
+    if (newObject == CK_TRUE || attrsFound == 1) {
+        if (objClass == CKO_CERTIFICATE) {
+            ret = WP11_Object_SetCert(obj, data, len);
         }
+        else {
+            /* Set the value and length of key specific attributes
+            * Old key data is cleared.
+            */
+            switch (type) {
+        #ifndef NO_RSA
+                case CKK_RSA:
+                    ret = WP11_Object_SetRsaKey(obj, data, len);
+                    break;
+        #endif
+        #ifdef HAVE_ECC
+                case CKK_EC:
+                    ret = WP11_Object_SetEcKey(obj, data, len);
+                    break;
+        #endif
+        #ifndef NO_DH
+                case CKK_DH:
+                    ret = WP11_Object_SetDhKey(obj, data, len);
+                    break;
+        #endif
+        #ifndef NO_AES
+                case CKK_AES:
+        #endif
+        #ifdef WOLFPKCS11_HKDF
+                case CKK_HKDF:
+        #endif
+                case CKK_GENERIC_SECRET:
+                    ret = WP11_Object_SetSecretKey(obj, data, len);
+                    break;
+                default:
+                    break;
+            }
+        }
+        if (ret == MEMORY_E)
+            return CKR_DEVICE_MEMORY;
+        if (ret != 0)
+            return CKR_FUNCTION_FAILED;
     }
-    if (ret == MEMORY_E)
-        return CKR_DEVICE_MEMORY;
-    if (ret != 0)
-        return CKR_FUNCTION_FAILED;
 
     /* Set remaining attributes - key specific attributes ignored. */
     for (i = 0; i < (int)ulCount; i++) {
@@ -659,7 +665,7 @@ static CK_RV NewObject(WP11_Session* session, CK_KEY_TYPE keyType,
     if (ret != 0)
         return CKR_FUNCTION_FAILED;
 
-    rv = SetAttributeValue(session, obj, pTemplate, ulCount);
+    rv = SetAttributeValue(session, obj, pTemplate, ulCount, CK_TRUE);
     if (rv != CKR_OK) {
         WP11_Object_Free(obj);
         return rv;
@@ -1042,7 +1048,7 @@ CK_RV C_CopyObject(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject,
         WP11_Object_Free(newObj);
         return rv;
     }
-    rv = SetAttributeValue(session, newObj, pTemplate, ulCount);
+    rv = SetAttributeValue(session, newObj, pTemplate, ulCount, CK_TRUE);
     if (rv != CKR_OK) {
         WP11_Object_Free(newObj);
         return rv;
@@ -1240,7 +1246,7 @@ CK_RV C_SetAttributeValue(CK_SESSION_HANDLE hSession,
     if (ret != 0)
         return CKR_OBJECT_HANDLE_INVALID;
 
-    return SetAttributeValue(session, obj, pTemplate, ulCount);
+    return SetAttributeValue(session, obj, pTemplate, ulCount, CK_FALSE);
 }
 
 /**

--- a/src/internal.c
+++ b/src/internal.c
@@ -204,7 +204,6 @@ struct WP11_Object {
     CK_MECHANISM_TYPE keyGenMech;      /* Key Gen mechanism created with      */
     byte onToken:1;                    /* Object on token or session          */
     byte local:1;                      /* Locally created object              */
-    word32 flag;                       /* Flags about object                  */
     word32 opFlag;                     /* Flags of operations allowed         */
 
     char startDate[8];                 /* Start date of usage                 */
@@ -783,7 +782,7 @@ static int wolfPKCS11_Store_GetMaxSize(int type, int variableSz)
                 FIELD_SIZE(WP11_Object, keyGenMech) +
                 1 /* FIELD_SIZE(WP11_Object, onToken) */ +
                 1 /* FIELD_SIZE(WP11_Object, local) */ +
-                FIELD_SIZE(WP11_Object, flag) +
+                4 /* FIELD_SIZE(WP11_Object, flag) */ +
                 FIELD_SIZE(WP11_Object, opFlag) +
                 FIELD_SIZE(WP11_Object, startDate) +
                 FIELD_SIZE(WP11_Object, endDate) +
@@ -3070,6 +3069,7 @@ static int wp11_Object_Load_Object(WP11_Object* object, int tokenId, int objId)
 {
     int ret;
     void* storage = NULL;
+    word32 dummy = 0;
 
     /* Open access to key object. */
     ret = wp11_storage_open_readonly(WOLFPKCS11_STORE_OBJECT, tokenId, objId,
@@ -3107,8 +3107,8 @@ static int wp11_Object_Load_Object(WP11_Object* object, int tokenId, int objId)
             }
         }
         if (ret == 0) {
-            /* Read the flags of the object. (4) */
-            ret = wp11_storage_read_word32(storage, &object->flag);
+            /* Unused word32. (4) */
+            ret = wp11_storage_read_word32(storage, &dummy);
         }
         if (ret == 0) {
             /* Read the operational flags of the object. (4) */
@@ -3198,6 +3198,7 @@ static int wp11_Object_Store_Object(WP11_Object* object, int tokenId, int objId)
 {
     int ret;
     void* storage = NULL;
+    word32 dummy = 0;
     int variableSz = (object->keyIdLen + object->labelLen);
 
     /* Open access to key object. */
@@ -3228,8 +3229,8 @@ static int wp11_Object_Store_Object(WP11_Object* object, int tokenId, int objId)
             ret = wp11_storage_write_boolean(storage, object->local);
         }
         if (ret == 0) {
-            /* Write the flags of the object. (4) */
-            ret = wp11_storage_write_word32(storage, object->flag);
+            /* Unused word32. (4) */
+            ret = wp11_storage_write_word32(storage, dummy);
         }
         if (ret == 0) {
             /* Write the operational flags of the object. (4) */
@@ -6522,8 +6523,8 @@ static int RsaObject_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
                              byte* data, CK_ULONG* len)
 {
     int ret = 0;
-    int noPriv = (((object->flag & WP11_FLAG_SENSITIVE) != 0) ||
-                                 ((object->flag & WP11_FLAG_EXTRACTABLE) == 0));
+    int noPriv = (((object->opFlag & WP11_FLAG_SENSITIVE) != 0) ||
+                 ((object->opFlag & WP11_FLAG_EXTRACTABLE) == 0));
 
     if (mp_iszero(&object->data.rsaKey.d))
         noPriv = 1;
@@ -6673,8 +6674,8 @@ static int EcObject_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
                             byte* data, CK_ULONG* len)
 {
     int ret = 0;
-    int noPriv = (((object->flag & WP11_FLAG_SENSITIVE) != 0) ||
-                                 ((object->flag & WP11_FLAG_EXTRACTABLE) == 0));
+    int noPriv = (((object->opFlag & WP11_FLAG_SENSITIVE) != 0) ||
+                 ((object->opFlag & WP11_FLAG_EXTRACTABLE) == 0));
     int noPub = 0;
 
     if (object->data.ecKey.type == ECC_PUBLICKEY)
@@ -6727,8 +6728,8 @@ static int DhObject_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
                             byte* data, CK_ULONG* len)
 {
     int ret = 0;
-    int noPriv = (((object->flag & WP11_FLAG_SENSITIVE) != 0) ||
-                                 ((object->flag & WP11_FLAG_EXTRACTABLE) == 0));
+    int noPriv = (((object->opFlag & WP11_FLAG_SENSITIVE) != 0) ||
+                 ((object->opFlag & WP11_FLAG_EXTRACTABLE) == 0));
 
     switch (type) {
         case CKA_PRIME:
@@ -6800,8 +6801,8 @@ static int SecretObject_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
                                 byte* data, CK_ULONG* len)
 {
     int ret = 0;
-    int noPriv = ((object->flag & WP11_FLAG_SENSITIVE) != 0 ||
-                                   (object->flag & WP11_FLAG_EXTRACTABLE) == 0);
+    int noPriv = ((object->opFlag & WP11_FLAG_SENSITIVE) != 0 ||
+                 (object->opFlag & WP11_FLAG_EXTRACTABLE) == 0);
 
     switch (type) {
         case CKA_VALUE:
@@ -6820,6 +6821,9 @@ static int SecretObject_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
             ret = NOT_AVAILABLE_E;
             break;
     }
+
+    if (noPriv && ret == CKR_OK)
+        ret = CKR_ATTRIBUTE_SENSITIVE;
 
     return ret;
 }
@@ -6928,31 +6932,33 @@ int WP11_Object_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
             break;
 
         case CKA_ENCRYPT:
-            ret = GetOpFlagBool(object->opFlag, CKF_ENCRYPT, data, len);
+            ret = GetOpFlagBool(object->opFlag, WP11_FLAG_ENCRYPT, data, len);
             break;
         case CKA_DECRYPT:
-            ret = GetOpFlagBool(object->opFlag, CKF_DECRYPT, data, len);
+            ret = GetOpFlagBool(object->opFlag, WP11_FLAG_DECRYPT, data, len);
             break;
         case CKA_VERIFY:
-            ret = GetOpFlagBool(object->opFlag, CKF_VERIFY, data, len);
+            ret = GetOpFlagBool(object->opFlag, WP11_FLAG_VERIFY, data, len);
             break;
         case CKA_VERIFY_RECOVER:
-            ret = GetOpFlagBool(object->opFlag, CKF_VERIFY_RECOVER, data, len);
+            ret = GetOpFlagBool(object->opFlag, WP11_FLAG_VERIFY_RECOVER, data,
+                                len);
             break;
         case CKA_SIGN:
-            ret = GetOpFlagBool(object->opFlag, CKF_SIGN, data, len);
+            ret = GetOpFlagBool(object->opFlag, WP11_FLAG_SIGN, data, len);
             break;
         case CKA_SIGN_RECOVER:
-            ret = GetOpFlagBool(object->opFlag, CKF_SIGN_RECOVER, data, len);
+            ret = GetOpFlagBool(object->opFlag, WP11_FLAG_SIGN_RECOVER, data,
+                                len);
             break;
         case CKA_WRAP:
-            ret = GetOpFlagBool(object->opFlag, CKF_WRAP, data, len);
+            ret = GetOpFlagBool(object->opFlag, WP11_FLAG_WRAP, data, len);
             break;
         case CKA_UNWRAP:
-            ret = GetOpFlagBool(object->opFlag, CKF_UNWRAP, data, len);
+            ret = GetOpFlagBool(object->opFlag, WP11_FLAG_UNWRAP, data, len);
             break;
         case CKA_DERIVE:
-            ret = GetOpFlagBool(object->opFlag, CKF_DERIVE, data, len);
+            ret = GetOpFlagBool(object->opFlag, WP11_FLAG_DERIVE, data, len);
             break;
 
         case CKA_SUBJECT:
@@ -7081,21 +7087,6 @@ static int WP11_Object_SetLabel(WP11_Object* object, unsigned char* label,
 }
 
 /**
- * Set the flag against the object.
- *
- * @param  object  [in]  Object object.
- * @param  flags   [in]  Flag value.
- * @param  set     [in]  Whether the flag is to be set (or cleared).
- */
-static void WP11_Object_SetFlag(WP11_Object* object, word32 flag, int set)
-{
-    if (set)
-        object->flag |= flag;
-    else
-        object->flag &= ~flag;
-}
-
-/**
  * Set the start date.
  *
  * @param  object     [in]  Object object.
@@ -7163,31 +7154,33 @@ int WP11_Object_SetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
             object->objClass = *(CK_ULONG*)data;
             break;
         case CKA_DECRYPT:
-            WP11_Object_SetOpFlag(object, CKF_DECRYPT, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_DECRYPT, *(CK_BBOOL*)data);
             break;
         case CKA_ENCRYPT:
-            WP11_Object_SetOpFlag(object, CKF_ENCRYPT, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_ENCRYPT, *(CK_BBOOL*)data);
             break;
         case CKA_SIGN:
-            WP11_Object_SetOpFlag(object, CKF_SIGN, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_SIGN, *(CK_BBOOL*)data);
             break;
         case CKA_VERIFY:
-            WP11_Object_SetOpFlag(object, CKF_VERIFY, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_VERIFY, *(CK_BBOOL*)data);
             break;
         case CKA_SIGN_RECOVER:
-            WP11_Object_SetOpFlag(object, CKF_SIGN_RECOVER, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_SIGN_RECOVER,
+                                  *(CK_BBOOL*)data);
             break;
         case CKA_VERIFY_RECOVER:
-            WP11_Object_SetOpFlag(object, CKF_VERIFY_RECOVER, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_VERIFY_RECOVER,
+                                  *(CK_BBOOL*)data);
             break;
         case CKA_WRAP:
-            WP11_Object_SetOpFlag(object, CKF_WRAP, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_WRAP, *(CK_BBOOL*)data);
             break;
         case CKA_UNWRAP:
-            WP11_Object_SetOpFlag(object, CKF_WRAP, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_UNWRAP, *(CK_BBOOL*)data);
             break;
         case CKA_DERIVE:
-            WP11_Object_SetOpFlag(object, CKF_DERIVE, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_DERIVE, *(CK_BBOOL*)data);
             break;
         case CKA_ID:
             ret = WP11_Object_SetKeyId(object, data, (int)len);
@@ -7196,36 +7189,38 @@ int WP11_Object_SetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
             ret = WP11_Object_SetLabel(object, data, (int)len);
             break;
         case CKA_PRIVATE:
-            WP11_Object_SetFlag(object, WP11_FLAG_PRIVATE, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_PRIVATE, *(CK_BBOOL*)data);
             break;
         case CKA_SENSITIVE:
-            WP11_Object_SetFlag(object, WP11_FLAG_SENSITIVE, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_SENSITIVE,
+                                  *(CK_BBOOL*)data);
             break;
         case CKA_EXTRACTABLE:
-            WP11_Object_SetFlag(object, WP11_FLAG_EXTRACTABLE,
+            WP11_Object_SetOpFlag(object, WP11_FLAG_EXTRACTABLE,
                                                               *(CK_BBOOL*)data);
             break;
         case CKA_MODIFIABLE:
-            WP11_Object_SetFlag(object, WP11_FLAG_MODIFIABLE, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_MODIFIABLE,
+                                  *(CK_BBOOL*)data);
             break;
         case CKA_ALWAYS_SENSITIVE:
-            WP11_Object_SetFlag(object, WP11_FLAG_ALWAYS_SENSITIVE,
-                                                              *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_ALWAYS_SENSITIVE,
+                                  *(CK_BBOOL*)data);
             break;
         case CKA_NEVER_EXTRACTABLE:
-            WP11_Object_SetFlag(object, WP11_FLAG_NEVER_EXTRACTABLE,
-                                                              *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_NEVER_EXTRACTABLE,
+                                  *(CK_BBOOL*)data);
             break;
         case CKA_ALWAYS_AUTHENTICATE:
-            WP11_Object_SetFlag(object, WP11_FLAG_ALWAYS_AUTHENTICATE,
-                                                              *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_ALWAYS_AUTHENTICATE,
+                                  *(CK_BBOOL*)data);
             break;
         case CKA_WRAP_WITH_TRUSTED:
-            WP11_Object_SetFlag(object, WP11_FLAG_WRAP_WITH_TRUSTED,
-                                                              *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_WRAP_WITH_TRUSTED,
+                                  *(CK_BBOOL*)data);
             break;
         case CKA_TRUSTED:
-            WP11_Object_SetFlag(object, WP11_FLAG_TRUSTED, *(CK_BBOOL*)data);
+            WP11_Object_SetOpFlag(object, WP11_FLAG_TRUSTED, *(CK_BBOOL*)data);
             break;
         case CKA_START_DATE:
             ret = WP11_Object_SetStartDate(object, (char*)data, (int)len);

--- a/tests/pkcs11mtt.c
+++ b/tests/pkcs11mtt.c
@@ -822,7 +822,8 @@ static CK_RV test_attributes_secret(void* args)
     ret = get_generic_key(session, keyData, sizeof(keyData), CK_FALSE, &key);
     if (ret == CKR_OK) {
         ret = funcList->C_GetAttributeValue(session, key, tmpl, tmplCnt);
-        CHECK_CKR(ret, "Get Attributes Secret Key");
+        CHECK_CKR_FAIL(ret, CKR_ATTRIBUTE_SENSITIVE,
+                       "Get Attributes Secret Key");
     }
     if (ret == CKR_OK) {
         for (i = 0; i < (int)badTmplCnt; i++) {

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -5887,6 +5887,57 @@ static CK_RV test_ecc_curve(void *args)
 }
 #endif
 
+/* Calling C_SetAttributeValue used to erase a key */
+static CK_RV test_ecc_key_erase_bug(void* args)
+{
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_RV ret = CKR_OK;
+    CK_OBJECT_HANDLE obj;
+    byte keyGet[sizeof(ecc_p256_priv)];
+    CK_ATTRIBUTE ecc_p256_priv_key[] = {
+        { CKA_CLASS,             &privKeyClass,     sizeof(privKeyClass)      },
+        { CKA_KEY_TYPE,          &eccKeyType,       sizeof(eccKeyType)        },
+        { CKA_VERIFY,            &ckTrue,           sizeof(ckTrue)            },
+        { CKA_EC_PARAMS,         ecc_p256_params,   sizeof(ecc_p256_params)   },
+        { CKA_VALUE,             ecc_p256_priv,     sizeof(ecc_p256_priv)     },
+    };
+    static int ecc_p256_priv_key_cnt =
+                           sizeof(ecc_p256_priv_key)/sizeof(*ecc_p256_priv_key);
+    CK_ATTRIBUTE updateTmpl[] = {
+        { CKA_EXTRACTABLE,         &ckTrue,         sizeof(ckTrue)            },
+    };
+    CK_ULONG updateTmplCnt = sizeof(updateTmpl) / sizeof(*updateTmpl);
+
+    CK_ATTRIBUTE getTmpl[] = {
+        { CKA_VALUE,          keyGet,   sizeof(ecc_p256_priv) },
+    };
+    CK_ULONG getTmplCnt = sizeof(getTmpl) / sizeof(*getTmpl);
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_CreateObject(session, ecc_p256_priv_key,
+                                                   ecc_p256_priv_key_cnt, &obj);
+        CHECK_CKR(ret, "EC Private Key Create Object");
+    }
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_SetAttributeValue(session, obj, updateTmpl,
+                                            updateTmplCnt);
+        CHECK_CKR(ret, "Update attribute sensitive");
+    }
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_GetAttributeValue(session, obj, getTmpl, getTmplCnt);
+        CHECK_CKR(ret, "Get key value");
+    }
+
+    if (ret == CKR_OK) {
+        if (XMEMCMP(keyGet, ecc_p256_priv, sizeof(ecc_p256_priv)) != 0)
+            ret = CKR_FUNCTION_FAILED;
+        CHECK_CKR(ret, "Key compare");
+    }
+    return ret;
+}
+
 static CK_RV test_ecc_create_key_fail(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
@@ -11191,6 +11242,7 @@ static TEST_FUNC testFunc[] = {
 #ifndef WOLFPKCS11_TPM
     PKCS11TEST_FUNC_SESS_DECL(test_ecc_curve),
 #endif
+    PKCS11TEST_FUNC_SESS_DECL(test_ecc_key_erase_bug),
     PKCS11TEST_FUNC_SESS_DECL(test_ecc_create_key_fail),
     PKCS11TEST_FUNC_SESS_DECL(test_ecc_fixed_keys_ecdh),
     PKCS11TEST_FUNC_SESS_DECL(test_ecc_fixed_keys_ecdsa),

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -109,15 +109,24 @@ extern "C" {
 #endif
 
 /* Flags for object. */
-#define WP11_FLAG_PRIVATE              0x0001
-#define WP11_FLAG_SENSITIVE            0x0002
-#define WP11_FLAG_EXTRACTABLE          0x0004
-#define WP11_FLAG_MODIFIABLE           0x0008
-#define WP11_FLAG_ALWAYS_SENSITIVE     0x0010
-#define WP11_FLAG_NEVER_EXTRACTABLE    0x0020
-#define WP11_FLAG_ALWAYS_AUTHENTICATE  0x0040
-#define WP11_FLAG_WRAP_WITH_TRUSTED    0x0080
-#define WP11_FLAG_TRUSTED              0x0100
+#define WP11_FLAG_PRIVATE              0x00000001
+#define WP11_FLAG_SENSITIVE            0x00000002
+#define WP11_FLAG_EXTRACTABLE          0x00000004
+#define WP11_FLAG_MODIFIABLE           0x00000008
+#define WP11_FLAG_ALWAYS_SENSITIVE     0x00000010
+#define WP11_FLAG_NEVER_EXTRACTABLE    0x00000020
+#define WP11_FLAG_ALWAYS_AUTHENTICATE  0x00000040
+#define WP11_FLAG_WRAP_WITH_TRUSTED    0x00000080
+#define WP11_FLAG_TRUSTED              0x00000100
+#define WP11_FLAG_DECRYPT              0x00000200
+#define WP11_FLAG_ENCRYPT              0x00000400
+#define WP11_FLAG_SIGN                 0x00000800
+#define WP11_FLAG_VERIFY               0x00001000
+#define WP11_FLAG_SIGN_RECOVER         0x00002000
+#define WP11_FLAG_VERIFY_RECOVER       0x00004000
+#define WP11_FLAG_UNWRAP               0x00008000
+#define WP11_FLAG_WRAP                 0x00010000
+#define WP11_FLAG_DERIVE               0x00020000
 
 /* Operation session has initialized for. */
 #define WP11_INIT_AES_CBC_ENC          0x0001


### PR DESCRIPTION
This solves a few problems with the boolean attributes and the key permission flags. `CKA_EXTRACTABLE` was never set to true, so private key attributes could never be retrieved. This led to some other problems found which are now fixed:

* Boolean flags were stored in `WP11_Object.flags` but read from `WP11_Object.opFlag`, so they were never readable.
* Default boolean flags were never set for keys.
* `CKA_SENSITIVE` could change from true to false.
* Wrong boolean masks were used when setting some of the attributes.
* `test_attribute_get` would pass when there is a failure.
* Unwrap attribute setter got mixed with wrap.

Note: The `WP11_Object` type will keep the `flags` variable but it is now unused. It needs to stay because it may have been stored and could be loaded in from somewhere. It is now for future use.

The second commit fixes the case where calling `C_SetAttributeValue()` on an ECC key will erase the key.