### PR TITLE
HKDF derive / data

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -77,7 +77,7 @@ jobs:
   no_hmac:
     uses: ./.github/workflows/build-workflow.yml
     with:
-      config: --disable-hmac
+      config: --disable-hmac --disable-hkdf
   with_nss:
     uses: ./.github/workflows/build-workflow.yml
     with:

--- a/configure.ac
+++ b/configure.ac
@@ -322,6 +322,16 @@ else
     DISABLE_DEFS="$DISABLE_DEFS -DNO_HMAC"
 fi
 
+AC_ARG_ENABLE([hkdf],
+    [AS_HELP_STRING([--enable-hkdf],[Enable HKDF (default: enabled)])],
+    [ ENABLED_HKDF=$enableval ],
+    [ ENABLED_HKDF=yes]
+    )
+if test "$ENABLED_HKDF" = "yes"
+then
+    AM_CFLAGS="$AM_CFLAGS -DWOLFPKCS11_HKDF"
+fi
+
 AC_ARG_ENABLE([md5],
     [AS_HELP_STRING([--enable-md5],[Enable MD5 (default: enabled)])],
     [ ENABLED_MD5=$enableval ],
@@ -599,4 +609,5 @@ echo "   * RSA-OAEP:                   $ENABLED_RSAOAEP"
 echo "   * RSA-PSS:                    $ENABLED_RSAPSS"
 echo "   * DH:                         $ENABLED_DH"
 echo "   * ECC:                        $ENABLED_ECC"
+echo "   * HKDF:                       $ENABLED_HKDF"
 echo "   * NSS modifications:          $ENABLED_NSS"

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -43,7 +43,8 @@
 
 #define CHECK_KEYTYPE(kt) \
    (kt == CKK_RSA || kt == CKK_EC || kt == CKK_DH || \
-    kt == CKK_AES || kt == CKK_GENERIC_SECRET) ? CKR_OK : CKR_ATTRIBUTE_VALUE_INVALID
+    kt == CKK_AES || kt == CKK_HKDF || kt == CKK_GENERIC_SECRET) ? \
+    CKR_OK : CKR_ATTRIBUTE_VALUE_INVALID
 
 #define CHECK_KEYCLASS(kc) \
     (kc == CKO_PRIVATE_KEY || kc == CKO_PUBLIC_KEY || kc == CKO_SECRET_KEY)? CKR_OK : CKR_ATTRIBUTE_VALUE_INVALID
@@ -368,6 +369,9 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
                 cnt = DH_KEY_PARAMS_CNT;
                 break;
         #endif
+        #ifdef WOLFPKCS11_HKDF
+            case CKK_HKDF:
+        #endif
         #ifndef NO_AES
             case CKK_AES:
         #endif
@@ -398,8 +402,8 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
     }
     else {
         /* Set the value and length of key specific attributes
-         * Old key data is cleared.
-         */
+        * Old key data is cleared.
+        */
         switch (type) {
     #ifndef NO_RSA
             case CKK_RSA:
@@ -415,6 +419,9 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
             case CKK_DH:
                 ret = WP11_Object_SetDhKey(obj, data, len);
                 break;
+    #endif
+    #ifdef WOLFPKCS11_HKDF
+            case CKK_HKDF:
     #endif
     #ifndef NO_AES
             case CKK_AES:
@@ -698,6 +705,12 @@ static CK_RV CreateObject(WP11_Session* session, CK_ATTRIBUTE_PTR pTemplate,
             return CKR_ATTRIBUTE_VALUE_INVALID;
         }
     }
+    else if (objectClass == CKO_DATA) {
+        FindAttributeType(pTemplate, ulCount, CKA_VALUE, &attr);
+        if (attr == NULL)
+            return CKR_TEMPLATE_INCOMPLETE;
+        objType = CKK_HKDF;
+    }
     else {
         FindAttributeType(pTemplate, ulCount, CKA_KEY_TYPE, &attr);
         if (attr == NULL)
@@ -709,7 +722,8 @@ static CK_RV CreateObject(WP11_Session* session, CK_ATTRIBUTE_PTR pTemplate,
         objType = *(CK_ULONG*)attr->pValue;
 
         if (objType != CKK_RSA && objType != CKK_EC && objType != CKK_DH &&
-            objType != CKK_AES && objType != CKK_GENERIC_SECRET) {
+            objType != CKK_AES && objType != CKK_HKDF &&
+            objType != CKK_GENERIC_SECRET) {
             return CKR_ATTRIBUTE_VALUE_INVALID;
         }
     }
@@ -5522,6 +5536,7 @@ static int SymmKeyLen(WP11_Object* obj, word32 len, word32* symmKeyLen)
 
     switch (WP11_Object_GetType(obj)) {
         case CKK_AES:
+        case CKK_HKDF:
         case CKK_GENERIC_SECRET:
         default:
             if (valueLen > 0 && valueLen <= len)
@@ -5568,7 +5583,7 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
     CK_RV rv = CKR_OK;
     WP11_Session* session;
     WP11_Object* obj = NULL;
-#if defined(HAVE_ECC) || !defined(NO_DH)
+#if defined(HAVE_ECC) || !defined(NO_DH) || defined(WOLFPKCS11_HKDF)
     byte* derivedKey = NULL;
     word32 keyLen;
     word32 symmKeyLen;
@@ -5616,6 +5631,41 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
                 rv = CKR_FUNCTION_FAILED;
             break;
         }
+#endif
+#ifdef WOLFPKCS11_HKDF
+        case CKM_HKDF_DERIVE:
+        case CKM_HKDF_DATA:
+            CK_HKDF_PARAMS_PTR kdfParams;
+            CK_ATTRIBUTE *lenAttr = NULL;
+
+            if (pMechanism->pParameter == NULL)
+                return CKR_MECHANISM_PARAM_INVALID;
+            if (pMechanism->ulParameterLen != sizeof(CK_HKDF_PARAMS))
+                return CKR_MECHANISM_PARAM_INVALID;
+            kdfParams = (CK_HKDF_PARAMS_PTR)pMechanism->pParameter;
+            if (!kdfParams->bExpand && !kdfParams->bExtract)
+                return CKR_MECHANISM_PARAM_INVALID;
+
+            FindAttributeType(pTemplate, ulAttributeCount, CKA_VALUE_LEN,
+                &lenAttr);
+            if (kdfParams->bExpand) {
+                if (!lenAttr) {
+                    return CKR_MECHANISM_PARAM_INVALID;
+                }
+                keyLen = *(CK_ULONG*)lenAttr->pValue;
+            }
+            else {
+                keyLen = WC_MAX_DIGEST_SIZE;
+            }
+            derivedKey = (byte*)XMALLOC(keyLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            if (derivedKey == NULL)
+                return CKR_DEVICE_MEMORY;
+
+            ret = WP11_KDF_Derive(session, kdfParams, derivedKey, &keyLen, obj);
+
+            if (ret != 0)
+                rv = CKR_FUNCTION_FAILED;
+            break;
 #endif
 #ifndef NO_DH
         case CKM_DH_PKCS_DERIVE:
@@ -5668,7 +5718,7 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
             return CKR_MECHANISM_INVALID;
     }
 
-#if defined(HAVE_ECC) || !defined(NO_DH) || \
+#if defined(HAVE_ECC) || !defined(NO_DH) || defined(WOLFPKCS11_HKDF) || \
     (!defined(NO_AES) && defined(HAVE_AES_CBC))
     if (ret == 0) {
         rv = CreateObject(session, pTemplate, ulAttributeCount, &obj);

--- a/src/internal.c
+++ b/src/internal.c
@@ -5104,8 +5104,8 @@ void WP11_Session_SetMechanism(WP11_Session* session,
     session->mechanism = mechanism;
 }
 
-#ifndef NO_RSA
-#if !defined(WC_NO_RSA_OAEP) || defined(WC_RSA_PSS)
+#if !defined(NO_RSA) || !defined(WC_NO_RSA_OAEP) || defined(WC_RSA_PSS) || \
+    defined(WOLFPKCS11_HKDF)
 /**
  * Convert the digest mechanism to a hash type for wolfCrypt.
  *
@@ -5121,18 +5121,23 @@ static int wp11_hash_type(CK_MECHANISM_TYPE hashMech,
 
     switch (hashMech) {
         case CKM_SHA1:
+        case CKM_SHA1_HMAC:
             *hashType = WC_HASH_TYPE_SHA;
             break;
         case CKM_SHA224:
+        case CKM_SHA224_HMAC:
             *hashType = WC_HASH_TYPE_SHA224;
             break;
         case CKM_SHA256:
+        case CKM_SHA256_HMAC:
             *hashType = WC_HASH_TYPE_SHA256;
             break;
         case CKM_SHA384:
+        case CKM_SHA384_HMAC:
             *hashType = WC_HASH_TYPE_SHA384;
             break;
         case CKM_SHA512:
+        case CKM_SHA512_HMAC:
             *hashType = WC_HASH_TYPE_SHA512;
             break;
         case CKM_SHA3_224:
@@ -5154,7 +5159,10 @@ static int wp11_hash_type(CK_MECHANISM_TYPE hashMech,
 
     return ret;
 }
+#endif
 
+#if !defined(NO_RSA)
+#if !defined(WC_NO_RSA_OAEP) || defined(WC_RSA_PSS)
 /**
  * Convert the mask generation function id to a wolfCrypt MGF id.
  *
@@ -6979,6 +6987,9 @@ int WP11_Object_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
         #ifndef NO_AES
                         case CKK_AES:
         #endif
+        #ifdef WOLFPKCS11_HKDF
+                        case CKK_HKDF:
+        #endif
                         case CKK_GENERIC_SECRET:
                             ret = SecretObject_GetAttr(object, type, data, len);
                             break;
@@ -7258,6 +7269,9 @@ int WP11_Object_SetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
 #ifndef NO_AES
                 case CKK_AES:
 #endif
+#ifdef WOLFPKCS11_HKDF
+                case CKK_HKDF:
+#endif
                 case CKK_GENERIC_SECRET:
                     break;
                 default:
@@ -7278,6 +7292,9 @@ int WP11_Object_SetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
 #endif
 #ifndef NO_AES
                 case CKK_AES:
+#endif
+#ifdef WOLFPKCS11_HKDF
+                case CKK_HKDF:
 #endif
                 case CKK_GENERIC_SECRET:
                    break;
@@ -8394,6 +8411,85 @@ int WP11_EC_Derive(unsigned char* point, word32 pointLen, unsigned char* key,
     return ret;
 }
 #endif /* HAVE_ECC */
+
+#ifdef WOLFPKCS11_HKDF
+
+/**
+ * Derive the secret from the private key with HKDF.
+ *
+ * @param  params     [in]  The salt and info parameters.
+ * @param  key        [in]  Buffer to hold the secret key.
+ * @param  keyLen     [in]  Buffer length in bytes.
+ * @param  priv       [in]  The private key.
+ * @return  -ve when derivation fails.
+ *          0 on success
+ */
+
+int WP11_KDF_Derive(WP11_Session* session, CK_HKDF_PARAMS_PTR params,
+                    unsigned char* key, word32* keyLen, WP11_Object* priv)
+{
+    int ret = 0;
+    byte* salt = NULL;
+    unsigned long saltLen = 0;
+    WP11_Object* saltKey = NULL;
+    enum wc_HashType hashType;
+    word32 hashLen;
+
+    ret = wp11_hash_type(params->prfHashMechanism, &hashType);
+
+    if (ret != 0) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+
+    hashLen = wc_HashGetDigestSize(hashType);
+
+    if (params->bExtract) {
+        switch (params->ulSaltType) {
+            case CKF_HKDF_SALT_NULL:
+                break;
+
+            case CKF_HKDF_SALT_DATA:
+                salt = params->pSalt;
+                saltLen = params->ulSaltLen;
+                break;
+
+            case CKF_HKDF_SALT_KEY:
+                ret = WP11_Object_Find(session, params->hSaltKey, &saltKey);
+                if (ret != 0)
+                    return CKR_OBJECT_HANDLE_INVALID;
+                salt = saltKey->data.symmKey.data;
+                saltLen = saltKey->data.symmKey.len;
+                break;
+
+            default:
+                return CKR_MECHANISM_PARAM_INVALID;
+                break;
+        }
+    }
+
+    if (params->bExtract && !params->bExpand) {
+        ret = wc_HKDF_Extract(hashType, salt, saltLen, priv->data.symmKey.data,
+            priv->data.symmKey.len, key);
+
+        if (!ret)
+            *keyLen = hashLen;
+    }
+    else if (!params->bExtract && params->bExpand) {
+        ret = wc_HKDF_Expand(hashType, priv->data.symmKey.data,
+            priv->data.symmKey.len, params->pInfo, params->ulInfoLen, key,
+            *keyLen);
+    }
+    else {
+        /* Both */
+        ret = wc_HKDF(hashType, priv->data.symmKey.data,priv->data.symmKey.len,
+            salt, saltLen, params->pInfo, params->ulInfoLen, key, *keyLen);
+    }
+
+
+    return ret;
+}
+
+#endif
 
 #ifndef NO_DH
 /**

--- a/src/slot.c
+++ b/src/slot.c
@@ -276,6 +276,10 @@ static CK_MECHANISM_TYPE mechanismList[] = {
 #endif
     CKM_ECDH1_DERIVE,
 #endif
+#ifdef WOLFPKCS11_HKDF
+    CKM_HKDF_DERIVE,
+    CKM_HKDF_DATA,
+#endif
 #ifndef NO_DH
     CKM_DH_PKCS_KEY_PAIR_GEN,
     CKM_DH_PKCS_DERIVE,
@@ -474,6 +478,14 @@ static CK_MECHANISM_INFO ecdsaSha512MechInfo = {
 /* Info on ECDH mechanism. */
 static CK_MECHANISM_INFO ecdhMechInfo = {
     256, 521, CKF_DERIVE
+};
+#endif
+#ifdef WOLFPKCS11_HKDF
+static CK_MECHANISM_INFO hkdfMechInfo = {
+    1, 16320, CKF_DERIVE
+};
+static CK_MECHANISM_INFO hkdfDatMechInfo = {
+    1, 16320, CKF_DERIVE
 };
 #endif
 #ifndef NO_DH
@@ -742,6 +754,14 @@ CK_RV C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type,
 #endif
         case CKM_ECDH1_DERIVE:
             XMEMCPY(pInfo, &ecdhMechInfo, sizeof(CK_MECHANISM_INFO));
+            break;
+#endif
+#ifdef WOLFPKCS11_HKDF
+        case CKM_HKDF_DERIVE:
+            XMEMCPY(pInfo, &hkdfMechInfo, sizeof(CK_MECHANISM_INFO));
+            break;
+        case CKM_HKDF_DATA:
+            XMEMCPY(pInfo, &hkdfDatMechInfo, sizeof(CK_MECHANISM_INFO));
             break;
 #endif
 #ifndef NO_DH

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -10290,6 +10290,589 @@ static CK_RV test_x509(void* args)
     return ret;
 }
 
+#ifdef WOLFPKCS11_HKDF
+static CK_RV test_hkdf_derive_extract_then_expand_salt_data(void* args)
+{
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_RV ret;
+    CK_OBJECT_HANDLE hDerivedKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hExpandKey = CK_INVALID_HANDLE;
+
+    CK_BYTE salt_bytes[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c
+    };
+    CK_BYTE expected_prk[] = {
+        0x07, 0x77, 0x09, 0x36, 0x2c, 0x2e, 0x32, 0xdf,
+        0x0d, 0xdc, 0x3f, 0x0d, 0xc4, 0x7b, 0xba, 0x63,
+        0x90, 0xb6, 0xc7, 0x3b, 0xb5, 0x0f, 0x9c, 0x31,
+        0x22, 0xec, 0x84, 0x4a, 0xd7, 0xc2, 0xb3, 0xe5
+    };
+    CK_BYTE ikm_tc1_hex[] = {
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b
+    };
+    CK_BYTE expected_okm[] = {
+        0x3c, 0xb2, 0x5f, 0x25, 0xfa, 0xac, 0xd5, 0x7a,
+        0x90, 0x43, 0x4f, 0x64, 0xd0, 0x36, 0x2f, 0x2a,
+        0x2d, 0x2d, 0x0a, 0x90, 0xcf, 0x1a, 0x5a, 0x4c,
+        0x5d, 0xb0, 0x2d, 0x56, 0xec, 0xc4, 0xc5, 0xbf,
+        0x34, 0x00, 0x72, 0x08, 0xd5, 0xb8, 0x87, 0x18,
+        0x58, 0x65
+    };
+    CK_BYTE info_bytes[] = {
+        0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
+        0xf8, 0xf9
+    };
+    CK_ULONG ikm_len = sizeof(ikm_tc1_hex);
+    CK_BYTE derived_value[32];
+    CK_BYTE derived_value2[42];
+    CK_ULONG derived_len = sizeof(derived_value);
+    CK_ULONG derived_len2 = sizeof(derived_value2);
+    CK_OBJECT_HANDLE hBaseKey1 = CK_INVALID_HANDLE;
+    CK_ATTRIBUTE templateB = {CKA_VALUE, NULL_PTR, 0};
+
+    CK_HKDF_PARAMS params = {
+        CK_TRUE,
+        CK_FALSE,
+        CKM_SHA256_HMAC,
+        CKF_HKDF_SALT_DATA,
+        salt_bytes,
+        sizeof(salt_bytes),
+        CK_INVALID_HANDLE,
+        NULL_PTR,
+        0
+    };
+
+    CK_MECHANISM mechanism = { CKM_HKDF_DERIVE, &params, sizeof(params) };
+
+    /* Template for the derived key (PRK) */
+    CK_ATTRIBUTE template[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_SENSITIVE, &ckFalse, sizeof(ckFalse)},
+        {CKA_EXTRACTABLE, &ckTrue, sizeof(ckTrue)},
+        {CKA_VALUE_LEN, &derived_len, sizeof(derived_len)}
+    };
+    CK_ULONG template_count = sizeof(template) / sizeof(template[0]);
+
+    CK_ATTRIBUTE templateExpand[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_SENSITIVE, &ckFalse, sizeof(ckFalse)},
+        {CKA_EXTRACTABLE, &ckTrue, sizeof(ckTrue)},
+        {CKA_VALUE_LEN, &derived_len2, sizeof(derived_len2)}
+    };
+    CK_ULONG templateExpand_count =
+        sizeof(templateExpand) / sizeof(templateExpand[0]);
+
+    CK_HKDF_PARAMS paramsExpand = {
+        CK_FALSE,
+        CK_TRUE,
+        CKM_SHA256_HMAC,
+        CKF_HKDF_SALT_NULL,
+        NULL_PTR,
+        0,
+        CK_INVALID_HANDLE,
+        info_bytes,
+        sizeof(info_bytes)
+    };
+
+    CK_MECHANISM mechanismExpand =
+        { CKM_HKDF_DERIVE, &paramsExpand, sizeof(paramsExpand) };
+
+    CK_ATTRIBUTE templateSecret[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_TOKEN, &ckFalse, sizeof(ckFalse)},
+        {CKA_PRIVATE, &ckTrue, sizeof(ckTrue)},
+        {CKA_SENSITIVE, &ckFalse, sizeof(ckFalse)},
+        {CKA_EXTRACTABLE, &ckTrue, sizeof(ckTrue)},
+        {CKA_VALUE, ikm_tc1_hex, ikm_len},
+        {CKA_VALUE_LEN, &ikm_len, sizeof(ikm_len)},
+        {CKA_DERIVE, &ckTrue, sizeof(ckTrue)}
+    };
+    CK_ULONG templateSecretCount =
+        sizeof(templateSecret) / sizeof(templateSecret[0]);
+
+    ret = funcList->C_CreateObject(session, templateSecret, templateSecretCount,
+        &hBaseKey1);
+    CHECK_CKR(ret, "Create object failed");
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_DeriveKey(session, &mechanism, hBaseKey1, template,
+            template_count, &hDerivedKey);
+        CHECK_CKR(ret, "C_DeriveKey failed");
+    }
+
+    /* Verify the derived key value */
+    if (ret == CKR_OK) {
+        templateB.ulValueLen = 0;
+        templateB.pValue = NULL_PTR;
+        ret = funcList->C_GetAttributeValue(session, hDerivedKey, &templateB,
+            1);
+        if (ret == CKR_BUFFER_TOO_SMALL)
+            ret = CKR_OK;
+        CHECK_CKR(ret, "Derived key length");
+    }
+    if (ret == CKR_OK) {
+        if (derived_len < templateB.ulValueLen) {
+            ret = CKR_BUFFER_TOO_SMALL;
+        }
+        CHECK_CKR(ret, "Buffer length");
+    }
+    if (ret == CKR_OK) {
+        templateB.pValue = derived_value;
+        ret = funcList->C_GetAttributeValue(session, hDerivedKey, &templateB,
+            1);
+        CHECK_CKR(ret, "Get value");
+    }
+
+    if (ret == CKR_OK) {
+        if (sizeof(expected_prk) != templateB.ulValueLen) {
+            ret = CKR_DATA_LEN_RANGE;
+            CHECK_CKR(ret, "Output length");
+        }
+    }
+
+    if (ret == CKR_OK) {
+        if (XMEMCMP(expected_prk, derived_value, sizeof(expected_prk))) {
+            ret = CKR_DATA_INVALID;
+            CHECK_CKR(ret, "Derived PRK doesn't match");
+        }
+    }
+
+    /* Test Expand */
+    if (ret == CKR_OK) {
+        ret = funcList->C_DeriveKey(session, &mechanismExpand, hDerivedKey,
+            templateExpand, templateExpand_count, &hExpandKey);
+        CHECK_CKR(ret, "Expand derive");
+    }
+
+    /* Verify the derived key value */
+    if (ret == CKR_OK) {
+        templateB.ulValueLen = 0;
+        templateB.pValue = NULL_PTR;
+        ret = funcList->C_GetAttributeValue(session, hExpandKey, &templateB,
+            1);
+        if (ret == CKR_BUFFER_TOO_SMALL)
+            ret = CKR_OK;
+        CHECK_CKR(ret, "Derived key length");
+    }
+    if (ret == CKR_OK) {
+        if (derived_len2 < templateB.ulValueLen) {
+            ret = CKR_BUFFER_TOO_SMALL;
+        }
+        CHECK_CKR(ret, "Buffer length");
+    }
+    if (ret == CKR_OK) {
+        templateB.pValue = derived_value2;
+        ret = funcList->C_GetAttributeValue(session, hExpandKey, &templateB,
+            1);
+        CHECK_CKR(ret, "Get value");
+    }
+    if (ret == CKR_OK) {
+        if (sizeof(expected_okm) != templateB.ulValueLen) {
+            ret = CKR_DATA_LEN_RANGE;
+            CHECK_CKR(ret, "Output length");
+        }
+    }
+
+    if (ret == CKR_OK) {
+        if (XMEMCMP(expected_okm, derived_value2, sizeof(expected_prk))) {
+            ret = CKR_DATA_INVALID;
+            CHECK_CKR(ret, "Derived PRK doesn't match");
+        }
+    }
+
+    return ret;
+}
+
+static CK_RV test_hkdf_derive_extract_with_expand_salt_data(void* args)
+{
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_RV ret;
+    CK_OBJECT_HANDLE hDerivedKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hBaseKey1 = CK_INVALID_HANDLE;
+
+    CK_BYTE salt_bytes[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c
+    };
+    CK_BYTE expected_okm[] = {
+        0x3c, 0xb2, 0x5f, 0x25, 0xfa, 0xac, 0xd5, 0x7a,
+        0x90, 0x43, 0x4f, 0x64, 0xd0, 0x36, 0x2f, 0x2a,
+        0x2d, 0x2d, 0x0a, 0x90, 0xcf, 0x1a, 0x5a, 0x4c,
+        0x5d, 0xb0, 0x2d, 0x56, 0xec, 0xc4, 0xc5, 0xbf,
+        0x34, 0x00, 0x72, 0x08, 0xd5, 0xb8, 0x87, 0x18,
+        0x58, 0x65
+    };
+    CK_BYTE info_bytes[] = {
+        0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
+        0xf8, 0xf9
+    };
+    CK_BYTE ikm_tc1_hex[] = {
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b
+    };
+    CK_ULONG ikm_len = sizeof(ikm_tc1_hex);
+
+    CK_BYTE derived_value[42];
+    CK_ULONG derived_len = sizeof(derived_value);
+
+    CK_HKDF_PARAMS params = {
+        CK_TRUE,
+        CK_TRUE,
+        CKM_SHA256_HMAC,
+        CKF_HKDF_SALT_DATA,
+        salt_bytes,
+        sizeof(salt_bytes),
+        CK_INVALID_HANDLE,
+        info_bytes,
+        sizeof(info_bytes)
+    };
+
+    CK_MECHANISM mechanism = { CKM_HKDF_DERIVE, &params, sizeof(params) };
+
+    // Template for the derived key (OKM)
+    CK_ATTRIBUTE template[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_SENSITIVE, &ckFalse, sizeof(ckFalse)},
+        {CKA_EXTRACTABLE, &ckTrue, sizeof(ckTrue)},
+        {CKA_VALUE_LEN, &derived_len, sizeof(derived_len)} // Expecting 42 bytes OKM
+    };
+    CK_ULONG template_count = sizeof(template) / sizeof(template[0]);
+
+    CK_ATTRIBUTE templateSecret[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_TOKEN, &ckFalse, sizeof(ckFalse)},
+        {CKA_PRIVATE, &ckTrue, sizeof(ckTrue)},
+        {CKA_SENSITIVE, &ckFalse, sizeof(ckFalse)},
+        {CKA_EXTRACTABLE, &ckTrue, sizeof(ckTrue)},
+        {CKA_VALUE, ikm_tc1_hex, ikm_len},
+        {CKA_VALUE_LEN, &ikm_len, sizeof(ikm_len)},
+        {CKA_DERIVE, &ckTrue, sizeof(ckTrue)}
+    };
+    CK_ULONG templateSecretCount =
+        sizeof(templateSecret) / sizeof(templateSecret[0]);
+
+
+    CK_ATTRIBUTE templateB = {CKA_VALUE, NULL_PTR, 0};
+
+    ret = funcList->C_CreateObject(session, templateSecret, templateSecretCount,
+        &hBaseKey1);
+    CHECK_CKR(ret, "Create object failed");
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_DeriveKey(session, &mechanism, hBaseKey1, template,
+            template_count, &hDerivedKey);
+        CHECK_CKR(ret, "Derive key");
+    }
+
+    if (ret == CKR_OK) {
+        templateB.ulValueLen = 0;
+        templateB.pValue = NULL_PTR;
+        ret = funcList->C_GetAttributeValue(session, hDerivedKey, &templateB,
+            1);
+        if (ret == CKR_BUFFER_TOO_SMALL)
+            ret = CKR_OK;
+        CHECK_CKR(ret, "Derived key length");
+    }
+    if (ret == CKR_OK) {
+        if (derived_len < templateB.ulValueLen) {
+            ret = CKR_BUFFER_TOO_SMALL;
+        }
+        CHECK_CKR(ret, "Buffer length");
+    }
+    if (ret == CKR_OK) {
+        templateB.pValue = derived_value;
+        ret = funcList->C_GetAttributeValue(session, hDerivedKey, &templateB,
+            1);
+        CHECK_CKR(ret, "Get value");
+    }
+
+    if (ret == CKR_OK) {
+        if (sizeof(expected_okm) != templateB.ulValueLen) {
+            ret = CKR_DATA_LEN_RANGE;
+            CHECK_CKR(ret, "Output length");
+        }
+    }
+
+    if (ret == CKR_OK) {
+        if (XMEMCMP(expected_okm, derived_value, sizeof(expected_okm))) {
+            ret = CKR_DATA_INVALID;
+            CHECK_CKR(ret, "Derived PRK doesn't match");
+        }
+    }
+
+    return ret;
+}
+
+/* Extract-and-Expand with NULL Salt */
+static CK_RV test_hkdf_derive_expand_with_extract_null_salt(void* args)
+{
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_RV ret;
+    CK_OBJECT_HANDLE hDerivedKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hBaseKey1 = CK_INVALID_HANDLE;
+
+    CK_BYTE expected_okm[] = {
+        0x8d, 0xa4, 0xe7, 0x75, 0xa5, 0x63, 0xc1, 0x8f,
+        0x71, 0x5f, 0x80, 0x2a, 0x06, 0x3c, 0x5a, 0x31,
+        0xb8, 0xa1, 0x1f, 0x5c, 0x5e, 0xe1, 0x87, 0x9e,
+        0xc3, 0x45, 0x4e, 0x5f, 0x3c, 0x73, 0x8d, 0x2d,
+        0x9d, 0x20, 0x13, 0x95, 0xfa, 0xa4, 0xb6, 0x1a,
+        0x96, 0xc8
+    };
+    CK_BYTE derived_value[42];
+    CK_ULONG derived_len = sizeof(derived_value);
+
+    CK_BYTE ikm_tc1_hex[] = {
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b
+    };
+    CK_ULONG ikm_len = sizeof(ikm_tc1_hex);
+
+    CK_HKDF_PARAMS params = {
+        CK_TRUE,
+        CK_TRUE,
+        CKM_SHA256_HMAC,
+        CKF_HKDF_SALT_NULL,
+        NULL_PTR,
+        0,
+        CK_INVALID_HANDLE,
+        NULL_PTR,
+        0
+    };
+
+    CK_MECHANISM mechanism = { CKM_HKDF_DERIVE, &params, sizeof(params) };
+
+    CK_ATTRIBUTE template[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_SENSITIVE, &ckFalse, sizeof(ckFalse)},
+        {CKA_EXTRACTABLE, &ckTrue, sizeof(ckTrue)},
+        {CKA_VALUE_LEN, &derived_len, sizeof(derived_len)}
+    };
+    CK_ULONG template_count = sizeof(template) / sizeof(template[0]);
+
+    CK_ATTRIBUTE templateSecret[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_TOKEN, &ckFalse, sizeof(ckFalse)},
+        {CKA_PRIVATE, &ckTrue, sizeof(ckTrue)},
+        {CKA_SENSITIVE, &ckFalse, sizeof(ckFalse)},
+        {CKA_EXTRACTABLE, &ckTrue, sizeof(ckTrue)},
+        {CKA_VALUE, ikm_tc1_hex, ikm_len},
+        {CKA_VALUE_LEN, &ikm_len, sizeof(ikm_len)},
+        {CKA_DERIVE, &ckTrue, sizeof(ckTrue)}
+    };
+    CK_ULONG templateSecretCount =
+        sizeof(templateSecret) / sizeof(templateSecret[0]);
+
+    CK_ATTRIBUTE templateB = {CKA_VALUE, NULL_PTR, 0};
+
+    ret = funcList->C_CreateObject(session, templateSecret, templateSecretCount,
+        &hBaseKey1);
+    CHECK_CKR(ret, "Create object failed");
+
+    if (ret == CKR_OK) {
+        ret= funcList->C_DeriveKey(session, &mechanism, hBaseKey1, template,
+            template_count, &hDerivedKey);
+        CHECK_CKR(ret, "Derive key");
+    }
+
+    if (ret == CKR_OK) {
+        templateB.ulValueLen = 0;
+        templateB.pValue = NULL_PTR;
+        ret = funcList->C_GetAttributeValue(session, hDerivedKey, &templateB,
+            1);
+        if (ret == CKR_BUFFER_TOO_SMALL)
+            ret = CKR_OK;
+        CHECK_CKR(ret, "Derived key length");
+    }
+    if (ret == CKR_OK) {
+        if (derived_len < templateB.ulValueLen) {
+            ret = CKR_BUFFER_TOO_SMALL;
+        }
+        CHECK_CKR(ret, "Buffer length");
+    }
+    if (ret == CKR_OK) {
+        templateB.pValue = derived_value;
+        ret = funcList->C_GetAttributeValue(session, hDerivedKey, &templateB,
+            1);
+        CHECK_CKR(ret, "Get value");
+    }
+
+    if (ret == CKR_OK) {
+        if (sizeof(expected_okm) != templateB.ulValueLen) {
+            ret = CKR_DATA_LEN_RANGE;
+            CHECK_CKR(ret, "Output length");
+        }
+    }
+
+    if (ret == CKR_OK) {
+        if (XMEMCMP(expected_okm, derived_value, sizeof(expected_okm))) {
+            ret = CKR_DATA_INVALID;
+            CHECK_CKR(ret, "Derived PRK doesn't match");
+        }
+    }
+
+    return ret;
+}
+
+
+static CK_RV test_hkdf_derive_extract_with_expand_salt_key(void* args)
+{
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_RV ret;
+    CK_OBJECT_HANDLE hDerivedKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hBaseKey1 = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hSaltKey1 = CK_INVALID_HANDLE;
+
+    CK_BYTE salt_bytes[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+        0x08, 0x09, 0x0a, 0x0b, 0x0c
+    };
+    CK_ULONG salt_bytes_len = sizeof(salt_bytes);
+    CK_BYTE expected_okm[] = {
+        0x3c, 0xb2, 0x5f, 0x25, 0xfa, 0xac, 0xd5, 0x7a,
+        0x90, 0x43, 0x4f, 0x64, 0xd0, 0x36, 0x2f, 0x2a,
+        0x2d, 0x2d, 0x0a, 0x90, 0xcf, 0x1a, 0x5a, 0x4c,
+        0x5d, 0xb0, 0x2d, 0x56, 0xec, 0xc4, 0xc5, 0xbf,
+        0x34, 0x00, 0x72, 0x08, 0xd5, 0xb8, 0x87, 0x18,
+        0x58, 0x65
+    };
+    CK_BYTE info_bytes[] = {
+        0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
+        0xf8, 0xf9
+    };
+    CK_BYTE ikm_tc1_hex[] = {
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+        0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b
+    };
+    CK_ULONG ikm_len = sizeof(ikm_tc1_hex);
+
+    CK_BYTE derived_value[42];
+    CK_ULONG derived_len = sizeof(derived_value);
+
+    // Template for the derived key (OKM)
+    CK_ATTRIBUTE template[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_SENSITIVE, &ckFalse, sizeof(ckFalse)},
+        {CKA_EXTRACTABLE, &ckTrue, sizeof(ckTrue)},
+        {CKA_VALUE_LEN, &derived_len, sizeof(derived_len)} // Expecting 42 bytes OKM
+    };
+    CK_ULONG template_count = sizeof(template) / sizeof(template[0]);
+
+    CK_ATTRIBUTE templateSecret[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_TOKEN, &ckFalse, sizeof(ckFalse)},
+        {CKA_PRIVATE, &ckTrue, sizeof(ckTrue)},
+        {CKA_SENSITIVE, &ckFalse, sizeof(ckFalse)},
+        {CKA_EXTRACTABLE, &ckTrue, sizeof(ckTrue)},
+        {CKA_VALUE, ikm_tc1_hex, ikm_len},
+        {CKA_VALUE_LEN, &ikm_len, sizeof(ikm_len)},
+        {CKA_DERIVE, &ckTrue, sizeof(ckTrue)}
+    };
+    CK_ULONG templateSecretCount =
+        sizeof(templateSecret) / sizeof(templateSecret[0]);
+
+    CK_ATTRIBUTE templateSalt[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_TOKEN, &ckFalse, sizeof(ckFalse)},
+        {CKA_PRIVATE, &ckTrue, sizeof(ckTrue)},
+        {CKA_SENSITIVE, &ckFalse, sizeof(ckFalse)},
+        {CKA_EXTRACTABLE, &ckTrue, sizeof(ckTrue)},
+        {CKA_VALUE, salt_bytes, salt_bytes_len},
+        {CKA_VALUE_LEN, &salt_bytes_len, sizeof(salt_bytes_len)},
+        {CKA_DERIVE, &ckTrue, sizeof(ckTrue)}
+    };
+    CK_ULONG templateSaltCount =
+        sizeof(templateSalt) / sizeof(templateSalt[0]);
+
+
+    CK_ATTRIBUTE templateB = {CKA_VALUE, NULL_PTR, 0};
+
+    ret = funcList->C_CreateObject(session, templateSecret, templateSecretCount,
+        &hBaseKey1);
+    CHECK_CKR(ret, "Create object failed");
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_CreateObject(session, templateSalt, templateSaltCount,
+            &hSaltKey1);
+        CHECK_CKR(ret, "Create object failed");
+    }
+
+    if (ret == CKR_OK) {
+        CK_HKDF_PARAMS params = {
+            CK_TRUE,
+            CK_TRUE,
+            CKM_SHA256_HMAC,
+            CKF_HKDF_SALT_KEY,
+            NULL_PTR,
+            0,
+            hSaltKey1,
+            info_bytes,
+            sizeof(info_bytes)
+        };
+
+        CK_MECHANISM mechanism = { CKM_HKDF_DERIVE, &params, sizeof(params) };
+        ret = funcList->C_DeriveKey(session, &mechanism, hBaseKey1, template,
+            template_count, &hDerivedKey);
+        CHECK_CKR(ret, "Derive key");
+    }
+
+    if (ret == CKR_OK) {
+        templateB.ulValueLen = 0;
+        templateB.pValue = NULL_PTR;
+        ret = funcList->C_GetAttributeValue(session, hDerivedKey, &templateB,
+            1);
+        if (ret == CKR_BUFFER_TOO_SMALL)
+            ret = CKR_OK;
+        CHECK_CKR(ret, "Derived key length");
+    }
+    if (ret == CKR_OK) {
+        if (derived_len < templateB.ulValueLen) {
+            ret = CKR_BUFFER_TOO_SMALL;
+        }
+        CHECK_CKR(ret, "Buffer length");
+    }
+    if (ret == CKR_OK) {
+        templateB.pValue = derived_value;
+        ret = funcList->C_GetAttributeValue(session, hDerivedKey, &templateB,
+            1);
+        CHECK_CKR(ret, "Get value");
+    }
+
+    if (ret == CKR_OK) {
+        if (sizeof(expected_okm) != templateB.ulValueLen) {
+            ret = CKR_DATA_LEN_RANGE;
+            CHECK_CKR(ret, "Output length");
+        }
+    }
+
+    if (ret == CKR_OK) {
+        if (XMEMCMP(expected_okm, derived_value, sizeof(expected_okm))) {
+            ret = CKR_DATA_INVALID;
+            CHECK_CKR(ret, "Derived PRK doesn't match");
+        }
+    }
+
+    return ret;
+}
+
+#endif
+
 static CK_RV test_random(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
@@ -10635,6 +11218,12 @@ static TEST_FUNC testFunc[] = {
     PKCS11TEST_FUNC_SESS_DECL(test_hmac_sha3_512),
     PKCS11TEST_FUNC_SESS_DECL(test_hmac_sha3_512_fail),
 #endif
+#endif
+#ifdef WOLFPKCS11_HKDF
+    PKCS11TEST_FUNC_SESS_DECL(test_hkdf_derive_extract_then_expand_salt_data),
+    PKCS11TEST_FUNC_SESS_DECL(test_hkdf_derive_extract_with_expand_salt_data),
+    PKCS11TEST_FUNC_SESS_DECL(test_hkdf_derive_expand_with_extract_null_salt),
+    PKCS11TEST_FUNC_SESS_DECL(test_hkdf_derive_extract_with_expand_salt_key),
 #endif
     PKCS11TEST_FUNC_SESS_DECL(test_random),
     PKCS11TEST_FUNC_SESS_DECL(test_x509),

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -48,6 +48,9 @@
 C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT"
 #endif
 
+#if defined(WOLFPKCS11_HKDF) && (!defined(HAVE_HKDF) || defined(NO_HMAC))
+#error Compiling with HKDF requires HMAC and wolfSSL to be compiled with HKDF.
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -312,6 +315,8 @@ int WP11_Object_SetSecretKey(WP11_Object* object, unsigned char** data,
                              CK_ULONG* len);
 int WP11_Object_SetCert(WP11_Object* object, unsigned char** data,
                              CK_ULONG* len);
+int WP11_Object_SetData(WP11_Object* object, unsigned char* data,
+                        CK_ULONG len);
 
 int WP11_Object_SetClass(WP11_Object* object, CK_OBJECT_CLASS objClass);
 CK_OBJECT_CLASS WP11_Object_GetClass(WP11_Object* object);
@@ -386,6 +391,9 @@ int WP11_Dh_GenerateKeyPair(WP11_Object* pub, WP11_Object* priv,
                             WP11_Slot* slot);
 int WP11_Dh_Derive(unsigned char* pub, word32 pubLen, unsigned char* key,
                    word32* keyLen, WP11_Object* priv);
+
+int WP11_KDF_Derive(WP11_Session* session, CK_HKDF_PARAMS_PTR params,
+                    unsigned char* key, word32* keyLen, WP11_Object* priv);
 
 int WP11_AesGenerateKey(WP11_Object* secret, WP11_Slot* slot);
 

--- a/wolfpkcs11/pkcs11.h
+++ b/wolfpkcs11/pkcs11.h
@@ -135,6 +135,7 @@ extern "C" {
 #define CKK_GENERIC_SECRET                    0x00000010UL
 #define CKK_AES                               0x0000001FUL
 #define CKK_DES3                              0x00000015UL /* not supported */
+#define CKK_HKDF                              0x00000042UL
 
 #define CKA_CLASS                             0x00000000UL
 #define CKA_TOKEN                             0x00000001UL
@@ -266,6 +267,9 @@ extern "C" {
 #define CKM_AES_CBC_ENCRYPT_DATA              0x00001105UL
 #define CKM_AES_KEY_WRAP                      0x00002109UL
 #define CKM_AES_KEY_WRAP_PAD                  0x0000210AUL
+#define CKM_HKDF_DERIVE                       0x0000402AUL
+#define CKM_HKDF_DATA                         0x0000402BUL
+#define CKM_HKDF_KEY_GEN                      0x0000402CUL
 
 #define CKR_OK                                0x00000000UL
 #define CKR_CANCEL                            0x00000001UL
@@ -370,6 +374,10 @@ extern "C" {
 #define CKC_X_509_ATTR_CERT                   0x00000001UL
 #define CKC_WTLS                              0x00000002UL
 #define CKC_VENDOR_DEFINED                    0x80000000UL
+
+#define CKF_HKDF_SALT_NULL                    0x00000001UL
+#define CKF_HKDF_SALT_DATA                    0x00000002UL
+#define CKF_HKDF_SALT_KEY                     0x00000004UL
 
 typedef unsigned char     CK_BYTE;
 typedef CK_BYTE           CK_CHAR;
@@ -570,6 +578,19 @@ typedef CK_AES_CBC_ENCRYPT_DATA_PARAMS* CK_AES_CBC_ENCRYPT_DATA_PARAMS_PTR;
 
 typedef CK_ULONG CK_MAC_GENERAL_PARAMS;
 typedef CK_MAC_GENERAL_PARAMS* CK_MAC_GENERAL_PARAMS_PTR;
+
+typedef struct CK_HKDF_PARAMS {
+    CK_BBOOL bExtract;
+    CK_BBOOL bExpand;
+    CK_MECHANISM_TYPE prfHashMechanism;
+    CK_ULONG ulSaltType;
+    CK_BYTE_PTR pSalt;
+    CK_ULONG ulSaltLen;
+    CK_OBJECT_HANDLE hSaltKey;
+    CK_BYTE_PTR pInfo;
+    CK_ULONG ulInfoLen;
+} CK_HKDF_PARAMS;
+typedef CK_HKDF_PARAMS* CK_HKDF_PARAMS_PTR;
 
 typedef struct CK_AES_CTR_PARAMS {
     CK_ULONG ulCounterBits;


### PR DESCRIPTION
This adds HKDF derive and data functions, which are pretty much identical.

In theory `CKM_HKDF_DATA` should use a `CKO_DATA` class, in practice this doesn't happen when NSS uses wolfPKCS11 and for the default permissions it shouldn't make a difference.