### PR TITLE
Implement CKM_TLS12_* for C_DeriveKey

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -41,6 +41,8 @@
 #define ATTR_TYPE_DATA         2
 #define ATTR_TYPE_DATE         3
 
+#define PRF_KEY_SIZE            48
+
 #define CHECK_KEYTYPE(kt) \
    (kt == CKK_RSA || kt == CKK_EC || kt == CKK_DH || \
     kt == CKK_AES || kt == CKK_HKDF || kt == CKK_GENERIC_SECRET) ? \
@@ -5878,6 +5880,143 @@ static int SymmKeyLen(WP11_Object* obj, word32 len, word32* symmKeyLen)
 }
 #endif
 
+static int SetKeyExtract(WP11_Session* session, byte* ptr, CK_ULONG length,
+                         CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulAttributeCount,
+                         CK_BBOOL isMac, CK_OBJECT_HANDLE* handle)
+{
+    WP11_Object* secret = NULL;
+    int ret;
+    word32 symmKeyLen;
+    CK_KEY_TYPE keyType = CKK_GENERIC_SECRET;
+    CK_BBOOL ckTrue = CK_TRUE;
+    CK_BBOOL ckFalse = CK_FALSE;
+    unsigned char* secretKeyData[2] = { NULL, NULL };
+    CK_ULONG secretKeyLen[2] = { 0, 0 };
+
+    ret = CreateObject(session, pTemplate, ulAttributeCount, &secret);
+    if (ret != 0)
+        return CKR_OBJECT_HANDLE_INVALID;
+
+    ret = SymmKeyLen(secret, length, &symmKeyLen);
+    if (ret == 0) {
+        /* Only use the bottom part of the secret for the key. */
+        secretKeyData[1] = ptr + (length - symmKeyLen);
+        secretKeyLen[1] = length;
+        ret = WP11_Object_SetSecretKey(secret, secretKeyData, secretKeyLen);
+        if (ret != CKR_OK)
+            return CKR_FUNCTION_FAILED;
+        ret = AddObject(session, secret, pTemplate, ulAttributeCount, handle);
+        if (ret != CKR_OK) {
+            return ret;
+        }
+    }
+    if ((ret == 0) && (isMac)) {
+        ret = WP11_Object_SetAttr(secret, CKA_KEY_TYPE, (byte*)&keyType,
+                                  sizeof(keyType));
+        if (ret != CKR_OK)
+            return ret;
+
+        ret = WP11_Object_SetAttr(secret, CKA_DERIVE, &ckTrue,
+                                  sizeof(CK_BBOOL));
+        if (ret != CKR_OK)
+            return ret;
+
+        ret = WP11_Object_SetAttr(secret, CKA_ENCRYPT, &ckFalse,
+                                  sizeof(CK_BBOOL));
+        if (ret != CKR_OK)
+            return ret;
+
+        ret = WP11_Object_SetAttr(secret, CKA_DECRYPT, &ckFalse,
+                                  sizeof(CK_BBOOL));
+        if (ret != CKR_OK)
+            return ret;
+
+        ret = WP11_Object_SetAttr(secret, CKA_SIGN, &ckTrue,
+                                  sizeof(CK_BBOOL));
+        if (ret != CKR_OK)
+            return ret;
+
+        ret = WP11_Object_SetAttr(secret, CKA_VERIFY, &ckTrue,
+                                  sizeof(CK_BBOOL));
+        if (ret != CKR_OK)
+            return ret;
+
+        ret = WP11_Object_SetAttr(secret, CKA_WRAP, &ckFalse,
+                                  sizeof(CK_BBOOL));
+        if (ret != CKR_OK)
+            return ret;
+
+        ret = WP11_Object_SetAttr(secret, CKA_UNWRAP, &ckFalse,
+                                  sizeof(CK_BBOOL));
+        if (ret != CKR_OK)
+            return ret;
+    }
+
+    return ret;
+}
+
+static int Tls12_Extract_Keys(WP11_Session* session,
+                            CK_TLS12_KEY_MAT_PARAMS* tlsParams,
+                            CK_ATTRIBUTE_PTR pTemplate,
+                            CK_ULONG ulAttributeCount, byte* derivedKey)
+{
+    int ret = 0;
+    unsigned char* ptr = derivedKey;
+    CK_ULONG length;
+
+    if (tlsParams == NULL) {
+        return CKR_FUNCTION_FAILED;
+    }
+
+    /* Client MAC key */
+    length = tlsParams->ulMacSizeInBits / 8;
+    ret = SetKeyExtract(session, ptr, length, pTemplate,
+            ulAttributeCount, CK_TRUE,
+            &tlsParams->pReturnedKeyMaterial->hClientMacSecret);
+    if (ret != 0) {
+        return ret;
+    }
+    ptr += length;
+    /* Server MAC key */
+    ret = SetKeyExtract(session, ptr, length, pTemplate,
+            ulAttributeCount, CK_TRUE,
+            &tlsParams->pReturnedKeyMaterial->hServerMacSecret);
+    if (ret != 0) {
+        return ret;
+    }
+    ptr += length;
+    /* Client key */
+    length = tlsParams->ulKeySizeInBits / 8;
+    ret = SetKeyExtract(session, ptr, length, pTemplate,
+            ulAttributeCount, CK_FALSE,
+            &tlsParams->pReturnedKeyMaterial->hClientKey);
+    if (ret != 0) {
+        return ret;
+    }
+    ptr += length;
+    /* Server key */
+    ret = SetKeyExtract(session, ptr, length, pTemplate,
+            ulAttributeCount, CK_FALSE,
+            &tlsParams->pReturnedKeyMaterial->hServerKey);
+    if (ret != 0) {
+        return ret;
+    }
+    ptr += length;
+    /* Client IV */
+    length = tlsParams->ulIVSizeInBits / 8;
+    if (tlsParams->pReturnedKeyMaterial->pIVClient != NULL) {
+        XMEMCPY(tlsParams->pReturnedKeyMaterial->pIVClient, ptr,
+                length);
+    }
+    ptr += length;
+    /* Server IV */
+    if (tlsParams->pReturnedKeyMaterial->pIVServer != NULL) {
+        XMEMCPY(tlsParams->pReturnedKeyMaterial->pIVServer, ptr,
+                length);
+    }
+    return ret;
+}
+
 /**
  * Generate a symmetric key into a new key object.
  *
@@ -5924,7 +6063,7 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
         return CKR_CRYPTOKI_NOT_INITIALIZED;
     if (WP11_Session_Get(hSession, &session) != 0)
         return CKR_SESSION_HANDLE_INVALID;
-    if (pMechanism == NULL || pTemplate == NULL || phKey == NULL)
+    if (pMechanism == NULL || pTemplate == NULL)
         return CKR_ARGUMENTS_BAD;
 
     ret = WP11_Object_Find(session, hBaseKey, &obj);
@@ -5936,6 +6075,8 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
         case CKM_ECDH1_DERIVE: {
             CK_ECDH1_DERIVE_PARAMS* params;
 
+            if (phKey == NULL)
+                return CKR_ARGUMENTS_BAD;
             if (pMechanism->pParameter == NULL)
                 return CKR_MECHANISM_PARAM_INVALID;
             if (pMechanism->ulParameterLen != sizeof(CK_ECDH1_DERIVE_PARAMS))
@@ -5967,6 +6108,8 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
             CK_HKDF_PARAMS_PTR kdfParams;
             CK_ATTRIBUTE *lenAttr = NULL;
 
+            if (phKey == NULL)
+                return CKR_ARGUMENTS_BAD;
             if (pMechanism->pParameter == NULL)
                 return CKR_MECHANISM_PARAM_INVALID;
             if (pMechanism->ulParameterLen != sizeof(CK_HKDF_PARAMS))
@@ -5999,6 +6142,8 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
 #endif
 #ifndef NO_DH
         case CKM_DH_PKCS_DERIVE:
+            if (phKey == NULL)
+                return CKR_ARGUMENTS_BAD;
             if (pMechanism->pParameter == NULL)
                 return CKR_MECHANISM_PARAM_INVALID;
             if (pMechanism->ulParameterLen == 0)
@@ -6020,7 +6165,8 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
 #ifdef HAVE_AES_CBC
         case CKM_AES_CBC_ENCRYPT_DATA: {
             CK_AES_CBC_ENCRYPT_DATA_PARAMS* params;
-
+            if (phKey == NULL)
+                return CKR_ARGUMENTS_BAD;
             if (pMechanism->pParameter == NULL)
                 return CKR_MECHANISM_PARAM_INVALID;
             if (pMechanism->ulParameterLen !=
@@ -6043,6 +6189,85 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
         }
 #endif
 #endif
+#ifdef WOLFSSL_HAVE_PRF
+        case CKM_TLS12_KEY_AND_MAC_DERIVE:
+            CK_TLS12_KEY_MAT_PARAMS* tlsParams = NULL;
+            if (pMechanism->pParameter == NULL)
+                return CKR_MECHANISM_PARAM_INVALID;
+            if (pMechanism->ulParameterLen !=
+                sizeof(CK_TLS12_KEY_MAT_PARAMS))
+                return CKR_MECHANISM_PARAM_INVALID;
+            tlsParams = (CK_TLS12_KEY_MAT_PARAMS*) pMechanism->pParameter;
+            if (tlsParams->pReturnedKeyMaterial == NULL)
+                return CKR_MECHANISM_PARAM_INVALID;
+
+            keyLen = (2 * tlsParams->ulMacSizeInBits) +
+                     (2 * tlsParams->ulKeySizeInBits) +
+                     (2 * tlsParams->ulIVSizeInBits);
+            if (keyLen == 0)
+                return CKR_MECHANISM_PARAM_INVALID;
+            if ((keyLen % 8) != 0)
+                return CKR_MECHANISM_PARAM_INVALID;
+            keyLen /= 8;
+
+            derivedKey = (byte*)XMALLOC(keyLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            if (derivedKey == NULL)
+                return CKR_DEVICE_MEMORY;
+            ret = WP11_Tls12_Master_Key_Derive(&tlsParams->RandomInfo,
+                                               tlsParams->prfHashMechanism,
+                                               "key expansion", 13,
+                                               derivedKey, keyLen, CK_FALSE,
+                                               obj);
+            if (ret == 0)
+                ret = Tls12_Extract_Keys(session, tlsParams, pTemplate,
+                                         ulAttributeCount, derivedKey);
+
+            XMEMSET(derivedKey, 0, keyLen);
+            XFREE(derivedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            derivedKey = NULL;
+
+            if (ret != 0)
+                rv = CKR_FUNCTION_FAILED;
+            break;
+        case CKM_TLS12_MASTER_KEY_DERIVE:
+        case CKM_TLS12_MASTER_KEY_DERIVE_DH:
+            CK_TLS12_MASTER_KEY_DERIVE_PARAMS* prfParams;
+            if (phKey == NULL)
+                return CKR_ARGUMENTS_BAD;
+            if (pMechanism->pParameter == NULL)
+                return CKR_MECHANISM_PARAM_INVALID;
+            if (pMechanism->ulParameterLen !=
+                sizeof(CK_TLS12_MASTER_KEY_DERIVE_PARAMS))
+                return CKR_MECHANISM_PARAM_INVALID;
+            prfParams = (CK_TLS12_MASTER_KEY_DERIVE_PARAMS*)
+                pMechanism->pParameter;
+            if (prfParams->RandomInfo.pClientRandom == NULL ||
+                prfParams->RandomInfo.pServerRandom == NULL)
+                return CKR_MECHANISM_PARAM_INVALID;
+
+            if (pMechanism->mechanism == CKM_TLS12_MASTER_KEY_DERIVE) {
+                if (prfParams->pVersion == NULL)
+                    return CKR_MECHANISM_PARAM_INVALID;
+                if ((prfParams->pVersion->major != 3) ||
+                    (prfParams->pVersion->minor != 3))
+                    return CKR_MECHANISM_INVALID;
+            }
+
+            keyLen = PRF_KEY_SIZE;
+            derivedKey = (byte*)XMALLOC(keyLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            if (derivedKey == NULL)
+                return CKR_DEVICE_MEMORY;
+
+            ret = WP11_Tls12_Master_Key_Derive(&prfParams->RandomInfo,
+                                               prfParams->prfHashMechanism,
+                                               "master secret", 13,
+                                               derivedKey, keyLen, CK_TRUE,
+                                               obj);
+
+            if (ret != 0)
+                rv = CKR_FUNCTION_FAILED;
+            break;
+#endif
         default:
             (void)ulAttributeCount;
             return CKR_MECHANISM_INVALID;
@@ -6050,7 +6275,7 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
 
 #if defined(HAVE_ECC) || !defined(NO_DH) || defined(WOLFPKCS11_HKDF) || \
     (!defined(NO_AES) && defined(HAVE_AES_CBC))
-    if (ret == 0) {
+    if ((ret == 0) && (derivedKey != NULL)) {
         rv = CreateObject(session, pTemplate, ulAttributeCount, &obj);
         if (rv == CKR_OK) {
             ret = SymmKeyLen(obj, keyLen, &symmKeyLen);
@@ -6059,12 +6284,12 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
                 secretKeyData[1] = derivedKey + (keyLen - symmKeyLen);
                 secretKeyLen[1] = keyLen;
                 ret = WP11_Object_SetSecretKey(obj, secretKeyData,
-                                                                  secretKeyLen);
+                                                secretKeyLen);
                 if (ret != 0)
                     rv = CKR_FUNCTION_FAILED;
                 if (ret == 0) {
-                    rv = AddObject(session, obj, pTemplate, ulAttributeCount,
-                                                                         phKey);
+                    rv = AddObject(session, obj, pTemplate,
+                                    ulAttributeCount, phKey);
                 }
             }
         }

--- a/src/internal.c
+++ b/src/internal.c
@@ -8751,6 +8751,29 @@ int WP11_Tls12_Master_Key_Derive(CK_SSL3_RANDOM_DATA* random,
 
     return ret;
 }
+#ifdef WOLFPKCS11_NSS
+int WP11_Nss_Tls12_Master_Key_Derive(CK_BYTE_PTR pSessionHash,
+                                     CK_ULONG ulSessionHashLen,
+                                     CK_MECHANISM_TYPE mech, const char* label,
+                                     CK_ULONG ulLabelLen, byte* enc,
+                                     CK_ULONG encLen, WP11_Object* key)
+{
+    int ret = 0;
+    enum wc_MACAlgorithm macType;
+
+    macType = MechToMac(mech);
+
+    if (macType == no_mac) {
+        return BAD_FUNC_ARG;
+    }
+
+    ret = wc_PRF_TLS(enc, encLen, key->data.symmKey.data, key->data.symmKey.len,
+                     (const byte*)label, ulLabelLen, pSessionHash,
+                     (word32)ulSessionHashLen, 1, macType, NULL, 0);
+
+    return ret;
+}
+#endif
 #endif
 
 /**

--- a/src/internal.c
+++ b/src/internal.c
@@ -40,6 +40,7 @@
 #include <wolfssl/wolfcrypt/asn_public.h>
 #include <wolfssl/wolfcrypt/aes.h>
 #include <wolfssl/wolfcrypt/cmac.h>
+#include <wolfssl/wolfcrypt/kdf.h>
 
 #include <wolfpkcs11/internal.h>
 #include <wolfpkcs11/store.h>
@@ -8681,6 +8682,76 @@ int WP11_AesCbc_DeriveKey(unsigned char* plain, word32 plainSz,
 
     return ret;
 }
+
+/* Used for wc_PRF_TLS, less than sha256_mac not possible */
+static enum wc_MACAlgorithm MechToMac(CK_MECHANISM_TYPE mech)
+{
+    switch (mech)
+    {
+        case CKM_SHA256:
+        case CKM_SHA256_HMAC:
+            return sha256_mac;
+        case CKM_SHA384:
+        case CKM_SHA384_HMAC:
+            return sha384_mac;
+        case CKM_SHA512:
+        case CKM_SHA512_HMAC:
+            return sha512_mac;
+        default:
+            return no_mac;
+    }
+}
+
+#ifdef WOLFSSL_HAVE_PRF
+int WP11_Tls12_Master_Key_Derive(CK_SSL3_RANDOM_DATA* random,
+                                 CK_MECHANISM_TYPE mech, const char* label,
+                                 CK_ULONG ulLabelLen, byte* enc,
+                                 CK_ULONG encLen, CK_BBOOL clientFirst,
+                                 WP11_Object* key)
+{
+    int ret = 0;
+    CK_ULONG ulSeedLen = 0;
+    byte* pSeed = NULL;
+    enum wc_MACAlgorithm macType;
+
+    macType = MechToMac(mech);
+
+    if (macType == no_mac) {
+        return BAD_FUNC_ARG;
+    }
+
+    ulSeedLen = random->ulClientRandomLen + random->ulServerRandomLen;
+    if (ulSeedLen == 0) {
+        return CKR_MECHANISM_PARAM_INVALID;
+    }
+    pSeed = (byte*)XMALLOC(ulSeedLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (pSeed == NULL) {
+        return CKR_HOST_MEMORY;
+    }
+    if (clientFirst) {
+        XMEMCPY(pSeed, random->pClientRandom, random->ulClientRandomLen);
+        XMEMCPY(pSeed + random->ulClientRandomLen, random->pServerRandom,
+                random->ulServerRandomLen);
+    }
+    else {
+        XMEMCPY(pSeed, random->pServerRandom, random->ulServerRandomLen);
+        XMEMCPY(pSeed + random->ulServerRandomLen, random->pClientRandom,
+                random->ulClientRandomLen);
+    }
+
+    ret = wc_PRF_TLS(enc, encLen, key->data.symmKey.data, key->data.symmKey.len,
+                     (const byte*)label, ulLabelLen, pSeed, (word32)ulSeedLen,
+                     1, macType, NULL, 0);
+
+    if (pSeed) {
+        XFREE(pSeed, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        pSeed = NULL;
+    }
+
+
+    return ret;
+}
+#endif
 
 /**
  * Encrypt plain text with AES-CBC.

--- a/src/slot.c
+++ b/src/slot.c
@@ -363,6 +363,10 @@ static CK_MECHANISM_TYPE mechanismList[] = {
     CKM_TLS12_KEY_AND_MAC_DERIVE,
     CKM_TLS12_MASTER_KEY_DERIVE,
     CKM_TLS12_MASTER_KEY_DERIVE_DH,
+#ifdef WOLFPKCS11_NSS
+    CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE,
+    CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH,
+#endif
 #endif
 };
 
@@ -513,6 +517,14 @@ static CK_MECHANISM_INFO tls12MasterKeyDeriveInfo = {
 static CK_MECHANISM_INFO tls12KeyAndMacDeriveInfo = {
     48, 48, CKF_DERIVE
 };
+#ifdef WOLFPKCS11_NSS
+static CK_MECHANISM_INFO nssTls12MasterKeyDeriveDhInfo = {
+    48, 128, CKF_DERIVE
+};
+static CK_MECHANISM_INFO nssTls12MasterKeyDeriveInfo = {
+    48, 128, CKF_DERIVE
+};
+#endif
 #endif
 #ifndef NO_AES
 static CK_MECHANISM_INFO aesKeyGenMechInfo = {
@@ -939,6 +951,16 @@ CK_RV C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type,
             XMEMCPY(pInfo, &tls12MasterKeyDeriveDhInfo,
                     sizeof(CK_MECHANISM_INFO));
             break;
+#ifdef WOLFPKCS11_NSS
+        case CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE:
+            XMEMCPY(pInfo, &nssTls12MasterKeyDeriveInfo,
+                    sizeof(CK_MECHANISM_INFO));
+            break;
+        case CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH:
+            XMEMCPY(pInfo, &nssTls12MasterKeyDeriveDhInfo,
+                    sizeof(CK_MECHANISM_INFO));
+            break;
+#endif
 #endif
         default:
             return CKR_MECHANISM_INVALID;

--- a/src/slot.c
+++ b/src/slot.c
@@ -355,9 +355,14 @@ static CK_MECHANISM_TYPE mechanismList[] = {
 #endif
 #ifndef WOLFSSL_NOSHA3_512
     CKM_SHA3_512_HMAC,
-    CKM_SHA3_512
+    CKM_SHA3_512,
 #endif
 #endif
+#endif
+#ifndef NO_KDF
+    CKM_TLS12_KEY_AND_MAC_DERIVE,
+    CKM_TLS12_MASTER_KEY_DERIVE,
+    CKM_TLS12_MASTER_KEY_DERIVE_DH,
 #endif
 };
 
@@ -496,6 +501,17 @@ static CK_MECHANISM_INFO dhKgMechInfo = {
 /* Info on DH key derivation mechanism. */
 static CK_MECHANISM_INFO dhPkcsMechInfo = {
     1024, 4096, CKF_DERIVE
+};
+#endif
+#ifndef NO_KDF
+static CK_MECHANISM_INFO tls12MasterKeyDeriveDhInfo = {
+    8, 128, CKF_DERIVE
+};
+static CK_MECHANISM_INFO tls12MasterKeyDeriveInfo = {
+    48, 48, CKF_DERIVE
+};
+static CK_MECHANISM_INFO tls12KeyAndMacDeriveInfo = {
+    48, 48, CKF_DERIVE
 };
 #endif
 #ifndef NO_AES
@@ -909,6 +925,20 @@ CK_RV C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type,
             XMEMCPY(pInfo, &sha3MechInfo, sizeof(CK_MECHANISM_INFO));
             break;
 #endif
+#endif
+#ifndef NO_KDF
+        case CKM_TLS12_KEY_AND_MAC_DERIVE:
+            XMEMCPY(pInfo, &tls12KeyAndMacDeriveInfo,
+                    sizeof(CK_MECHANISM_INFO));
+            break;
+        case CKM_TLS12_MASTER_KEY_DERIVE:
+            XMEMCPY(pInfo, &tls12MasterKeyDeriveInfo,
+                    sizeof(CK_MECHANISM_INFO));
+            break;
+        case CKM_TLS12_MASTER_KEY_DERIVE_DH:
+            XMEMCPY(pInfo, &tls12MasterKeyDeriveDhInfo,
+                    sizeof(CK_MECHANISM_INFO));
+            break;
 #endif
         default:
             return CKR_MECHANISM_INVALID;

--- a/tests/pkcs11mtt.c
+++ b/tests/pkcs11mtt.c
@@ -1919,6 +1919,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
     return ret;
 }
 
+#ifndef NO_DH
 static CK_RV test_derive_key(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
@@ -1984,6 +1985,7 @@ static CK_RV test_derive_key(void* args)
 
     return ret;
 }
+#endif
 
 #if !defined(NO_RSA) || defined(HAVE_ECC)
 static CK_RV test_pubkey_sig_fail(CK_SESSION_HANDLE session, CK_MECHANISM* mech,
@@ -6574,7 +6576,9 @@ static TEST_FUNC testFunc[] = {
     PKCS11MTT_CASE(test_generate_key),
     PKCS11MTT_CASE(test_generate_key_pair),
     PKCS11MTT_CASE(test_wrap_unwrap_key),
+#ifndef NO_DH
     PKCS11MTT_CASE(test_derive_key),
+#endif
 #ifndef NO_RSA
     PKCS11MTT_CASE(test_rsa_fixed_keys_raw),
     PKCS11MTT_CASE(test_rsa_fixed_keys_pkcs15_enc),

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -3540,6 +3540,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
     return ret;
 }
 
+#ifndef NO_DH
 static CK_RV test_derive_key(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
@@ -3602,6 +3603,7 @@ static CK_RV test_derive_key(void* args)
 
     return ret;
 }
+#endif
 
 #if !defined(NO_RSA) || defined(HAVE_ECC)
 static CK_RV test_pubkey_sig_fail(CK_SESSION_HANDLE session, CK_MECHANISM* mech,
@@ -11218,6 +11220,487 @@ static CK_RV test_random(void* args)
     return ret;
 }
 
+#ifdef WOLFSSL_HAVE_PRF
+static CK_RV test_derive_tls12_key_and_mac(void *args) {
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_RV ret;
+    CK_OBJECT_HANDLE premasterSecret;
+    unsigned char clientIV[16], serverIV[16];
+    CK_BBOOL trueValue = CK_TRUE;
+    CK_BBOOL falseValue = CK_FALSE;
+    CK_OBJECT_HANDLE hDerivedKey = CK_INVALID_HANDLE;
+    static unsigned char test_premaster_secret[] = {
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+        0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+        0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+        0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+        0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30
+    };
+
+    static unsigned char test_client_random[] = {
+        0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+        0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f, 0x70,
+        0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+        0x79, 0x7a, 0x7b, 0x7c, 0x7d, 0x7e, 0x7f, 0x80
+    };
+
+    static unsigned char test_server_random[] = {
+        0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+        0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50,
+        0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+        0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x5e, 0x5f, 0x60
+    };
+
+    static unsigned char expected_client_mac_key[] = {
+        0x2e, 0xe2, 0xcb, 0x38, 0xb5, 0xd8, 0x50, 0x90,
+        0xda, 0xc2, 0x87, 0x65, 0xeb, 0xfb, 0x59, 0x34,
+        0xb1, 0x54, 0xa3, 0xc8, 0x2a, 0x9d, 0xad, 0xed,
+        0x5f, 0xa3, 0x01, 0x79, 0xd8, 0x10, 0x93, 0xcc
+    };
+
+    static unsigned char expected_server_mac_key[] = {
+        0xdd, 0x6e, 0xc7, 0x90, 0x9d, 0xf9, 0xbf, 0x39,
+        0xec, 0x2f, 0x44, 0x89, 0x4a, 0xc4, 0x04, 0xfe,
+        0x93, 0xb9, 0x77, 0xff, 0xed, 0x96, 0x7d, 0x1f,
+        0xeb, 0x26, 0x61, 0x45, 0xfc, 0x48, 0x2d, 0x1b
+    };
+
+    static unsigned char expected_client_key[] = {
+        0x2a, 0xb4, 0x47, 0x20, 0x2e, 0x35, 0xd2, 0xe6,
+        0xe3, 0xdd, 0x71, 0x34, 0x84, 0x00, 0x9d, 0xb5
+    };
+
+    static unsigned char expected_server_key[] = {
+        0x19, 0xca, 0x53, 0x63, 0x3e, 0x49, 0x86, 0x63,
+        0x7f, 0x3d, 0x18, 0x12, 0xa3, 0x9d, 0x0a, 0x4a
+    };
+
+    static unsigned char expected_client_iv[] = {
+        0xb8, 0xdb, 0x5b, 0xf6, 0xce, 0x7e, 0x3a, 0x31,
+        0x97, 0x30, 0xbb, 0x57, 0x6f, 0xa7, 0xb1, 0x72
+    };
+
+    static unsigned char expected_server_iv[] = {
+        0x15, 0xe9, 0xad, 0xa0, 0x0b, 0xfe, 0x61, 0xd6,
+        0x3a, 0xfa, 0x1b, 0xc3, 0x8c, 0x4a, 0xa2, 0x95
+    };
+
+    CK_ATTRIBUTE premasterAttrs[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_VALUE, test_premaster_secret, sizeof(test_premaster_secret)},
+        {CKA_DERIVE, &trueValue, sizeof(trueValue)}
+    };
+
+    CK_SSL3_RANDOM_DATA randomInfo = {
+        test_client_random, sizeof(test_client_random),
+        test_server_random, sizeof(test_server_random)
+    };
+
+    CK_SSL3_KEY_MAT_OUT keyMaterialOut = {
+        CK_INVALID_HANDLE, CK_INVALID_HANDLE,
+        CK_INVALID_HANDLE, CK_INVALID_HANDLE,
+        clientIV, serverIV
+    };
+
+    CK_TLS12_KEY_MAT_PARAMS params = {
+        32*8,
+        16*8,
+        16*8,
+        CK_FALSE,
+        randomInfo,
+        &keyMaterialOut,
+        CKM_SHA256
+    };
+
+    CK_MECHANISM mechanism = {
+        CKM_TLS12_KEY_AND_MAC_DERIVE,
+        &params,
+        sizeof(params)
+    };
+
+    CK_ATTRIBUTE derivedKeyTemplate[] = {
+        {CKA_CLASS, &secretKeyClass, sizeof(secretKeyClass)},
+        {CKA_KEY_TYPE, &genericKeyType, sizeof(genericKeyType)},
+        {CKA_SENSITIVE, &falseValue, sizeof(falseValue)},
+        {CKA_EXTRACTABLE, &trueValue, sizeof(trueValue)},
+        {CKA_DERIVE, &trueValue, sizeof(trueValue)},
+        {CKA_ENCRYPT, &falseValue, sizeof(falseValue)},
+        {CKA_DECRYPT, &falseValue, sizeof(falseValue)},
+        {CKA_TOKEN, &falseValue, sizeof(falseValue)}
+    };
+    CK_ULONG ulDerivedKeyTemplateCount =
+        sizeof(derivedKeyTemplate) / sizeof(CK_ATTRIBUTE);
+
+    CK_BYTE derivedKeyValue[48];
+    CK_ATTRIBUTE getValueTemplate[] = {
+        {CKA_VALUE, derivedKeyValue, sizeof(derivedKeyValue)}
+    };
+    CK_ULONG ulGetValueTemplateCount =
+        sizeof(getValueTemplate) / sizeof(CK_ATTRIBUTE);
+
+    ret = funcList->C_CreateObject(session, premasterAttrs,
+                                sizeof(premasterAttrs) / sizeof(CK_ATTRIBUTE),
+                                &premasterSecret);
+    CHECK_CKR(ret, "Create object");
+    if (ret == CKR_OK) {
+        ret = funcList->C_DeriveKey(session, &mechanism, premasterSecret,
+                                    derivedKeyTemplate,
+                                    ulDerivedKeyTemplateCount, &hDerivedKey);
+        CHECK_CKR(ret, "Derive key");
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(hDerivedKey == CK_INVALID_HANDLE, ret,
+                   "No single derived key");
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(XMEMCMP(clientIV, expected_client_iv,
+                           sizeof(expected_client_iv)) == 0,
+                   ret, "Client IV compare");
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(XMEMCMP(serverIV, expected_server_iv,
+                           sizeof(expected_server_iv)) == 0,
+                   ret, "Server IV compare");
+    }
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_GetAttributeValue(session,
+                                            keyMaterialOut.hClientMacSecret,
+                                            getValueTemplate,
+                                            ulGetValueTemplateCount);
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(getValueTemplate[0].ulValueLen == 32, ret, "Get CKA_VALUE");
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(XMEMCMP(derivedKeyValue, expected_client_mac_key, 32) == 0,
+                   ret, "Client mac compare");
+    }
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_GetAttributeValue(session,
+                                            keyMaterialOut.hServerMacSecret,
+                                            getValueTemplate,
+                                            ulGetValueTemplateCount);
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(getValueTemplate[0].ulValueLen == 32, ret,
+                   "Get CKA_VALUE");
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(XMEMCMP(derivedKeyValue, expected_server_mac_key, 32) == 0,
+                   ret, "Client mac compare");
+    }
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_GetAttributeValue(session,
+                                            keyMaterialOut.hClientKey,
+                                            getValueTemplate,
+                                            ulGetValueTemplateCount);
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(getValueTemplate[0].ulValueLen == 16, ret,
+                   "Get CKA_VALUE");
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(XMEMCMP(derivedKeyValue, expected_client_key, 16) == 0,
+                   ret, "Client key compare");
+    }
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_GetAttributeValue(session,
+                                            keyMaterialOut.hServerKey,
+                                            getValueTemplate,
+                                            ulGetValueTemplateCount);
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(getValueTemplate[0].ulValueLen == 16, ret,
+                   "Get CKA_VALUE");
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(XMEMCMP(derivedKeyValue, expected_server_key, 16) == 0,
+                   ret, "Server key compare");
+    }
+
+    return ret;
+}
+
+static CK_RV test_derive_tls12_master_key_dh(void* args) {
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_RV ret;
+    CK_OBJECT_HANDLE hBaseKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hDerivedKey = CK_INVALID_HANDLE;
+
+    CK_BYTE preMasterSecret[] = {
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00
+    };
+    CK_ULONG ulPreMasterSecretLen = sizeof(preMasterSecret);
+
+    CK_BYTE clientRandom[] = {
+        0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+        0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+        0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+        0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA
+    };
+    CK_BYTE serverRandom[] = {
+        0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB,
+        0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB,
+        0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB,
+        0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB
+    };
+
+    /* Generated using Python scapy.layers.tls.crypto.prf */
+    CK_BYTE expectedMasterSecret[] = {
+        0xc8, 0x43, 0xf0, 0x67, 0xbf, 0xc2, 0x7b, 0xd6,
+        0xb6, 0x42, 0x26, 0x01, 0xe9, 0x1a, 0xc9, 0xb5,
+        0x32, 0xaa, 0x4b, 0xbb, 0x02, 0xd0, 0x1f, 0x20,
+        0xe9, 0x3b, 0x75, 0x60, 0x2d, 0x6d, 0x0d, 0xf1,
+        0x4f, 0x4b, 0xff, 0xff, 0x2a, 0x12, 0x9b, 0xf1,
+        0x6a, 0x4d, 0x16, 0x69, 0x07, 0x55, 0x38, 0x30
+    };
+    CK_ULONG ulExpectedMasterSecretLen = sizeof(expectedMasterSecret);
+
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_GENERIC_SECRET;
+    CK_BBOOL trueValue = CK_TRUE;
+    CK_BBOOL falseValue = CK_FALSE;
+
+    CK_ATTRIBUTE baseKeyTemplate[] = {
+        {CKA_CLASS, &keyClass, sizeof(keyClass)},
+        {CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+        {CKA_VALUE, preMasterSecret, ulPreMasterSecretLen},
+        {CKA_SENSITIVE, &falseValue, sizeof(falseValue)},
+        {CKA_EXTRACTABLE, &falseValue, sizeof(falseValue)},
+        {CKA_DERIVE, &trueValue, sizeof(trueValue)},
+        {CKA_TOKEN, &falseValue, sizeof(falseValue)}
+    };
+    CK_ULONG ulBaseKeyTemplateCount =
+        sizeof(baseKeyTemplate) / sizeof(CK_ATTRIBUTE);
+
+    CK_TLS12_MASTER_KEY_DERIVE_PARAMS params;
+    params.RandomInfo.pClientRandom = clientRandom;
+    params.RandomInfo.ulClientRandomLen = sizeof(clientRandom);
+    params.RandomInfo.pServerRandom = serverRandom;
+    params.RandomInfo.ulServerRandomLen = sizeof(serverRandom);
+    /* Version for TLS 1.2 is {3, 3} */
+    CK_VERSION version = {3, 3};
+    params.pVersion = &version;
+    params.prfHashMechanism = CKM_SHA256;
+    CK_MECHANISM mechanism = {
+        CKM_TLS12_MASTER_KEY_DERIVE_DH, &params, sizeof(params)
+    };
+
+    CK_ULONG derivedKeyLength = 48;
+    CK_KEY_TYPE derivedKeyType = CKK_GENERIC_SECRET;
+
+    CK_ATTRIBUTE derivedKeyTemplate[] = {
+        {CKA_CLASS, &keyClass, sizeof(keyClass)},
+        {CKA_KEY_TYPE, &derivedKeyType, sizeof(derivedKeyType)},
+        {CKA_SENSITIVE, &falseValue, sizeof(falseValue)},
+        {CKA_EXTRACTABLE, &trueValue, sizeof(trueValue)},
+        {CKA_DERIVE, &trueValue, sizeof(trueValue)},
+        {CKA_ENCRYPT, &falseValue, sizeof(falseValue)},
+        {CKA_DECRYPT, &falseValue, sizeof(falseValue)},
+        {CKA_TOKEN, &falseValue, sizeof(falseValue)},
+        {CKA_VALUE_LEN, &derivedKeyLength, sizeof(derivedKeyLength)}
+    };
+    CK_ULONG ulDerivedKeyTemplateCount =
+        sizeof(derivedKeyTemplate) / sizeof(CK_ATTRIBUTE);
+
+    CK_BYTE derivedKeyValue[48];
+    CK_ATTRIBUTE getValueTemplate[] = {
+        {CKA_VALUE, derivedKeyValue, sizeof(derivedKeyValue)}
+    };
+    CK_ULONG ulGetValueTemplateCount =
+        sizeof(getValueTemplate) / sizeof(CK_ATTRIBUTE);
+
+
+    ret = funcList->C_CreateObject(session, baseKeyTemplate,
+                                   ulBaseKeyTemplateCount, &hBaseKey);
+    CHECK_CKR(ret, "Base key");
+    if (ret == CKR_OK) {
+        ret = funcList->C_DeriveKey(session, &mechanism, hBaseKey,
+                                    derivedKeyTemplate,
+                                    ulDerivedKeyTemplateCount, &hDerivedKey);
+        CHECK_CKR(ret, "Derive key");
+    }
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_GetAttributeValue(session, hDerivedKey,
+                                            getValueTemplate,
+                                            ulGetValueTemplateCount);
+    }
+    if (ret == CKR_OK) {
+        CHECK_COND(getValueTemplate[0].ulValueLen == ulExpectedMasterSecretLen,
+                   ret, "Derived key length mismatch");
+    }
+    if (ret == CKR_OK) {
+        CHECK_COND(getValueTemplate[0].ulValueLen != (CK_ULONG)-1, ret,
+                   "Get CKA_VALUE");
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(XMEMCMP(derivedKeyValue, expectedMasterSecret,
+                           ulExpectedMasterSecretLen) == 0, ret,
+                   "Secret compare");
+    }
+
+    return ret;
+}
+
+static CK_RV test_derive_tls12_master_key(void* args) {
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_RV ret;
+    CK_OBJECT_HANDLE hBaseKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE hDerivedKey = CK_INVALID_HANDLE;
+
+    CK_BYTE preMasterSecret[] = {
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00,
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+        0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00
+    };
+    CK_ULONG ulPreMasterSecretLen = sizeof(preMasterSecret);
+
+    CK_BYTE clientRandom[] = {
+        0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+        0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+        0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+        0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA
+    };
+    CK_BYTE serverRandom[] = {
+        0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB,
+        0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB,
+        0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB,
+        0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB
+    };
+
+    /* Generated using Python scapy.layers.tls.crypto.prf */
+    CK_BYTE expectedMasterSecret[] = {
+        0xc8, 0x43, 0xf0, 0x67, 0xbf, 0xc2, 0x7b, 0xd6,
+        0xb6, 0x42, 0x26, 0x01, 0xe9, 0x1a, 0xc9, 0xb5,
+        0x32, 0xaa, 0x4b, 0xbb, 0x02, 0xd0, 0x1f, 0x20,
+        0xe9, 0x3b, 0x75, 0x60, 0x2d, 0x6d, 0x0d, 0xf1,
+        0x4f, 0x4b, 0xff, 0xff, 0x2a, 0x12, 0x9b, 0xf1,
+        0x6a, 0x4d, 0x16, 0x69, 0x07, 0x55, 0x38, 0x30
+    };
+    CK_ULONG ulExpectedMasterSecretLen = sizeof(expectedMasterSecret);
+
+    CK_OBJECT_CLASS keyClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE keyType = CKK_GENERIC_SECRET;
+    CK_BBOOL trueValue = CK_TRUE;
+    CK_BBOOL falseValue = CK_FALSE;
+
+    CK_ATTRIBUTE baseKeyTemplate[] = {
+        {CKA_CLASS, &keyClass, sizeof(keyClass)},
+        {CKA_KEY_TYPE, &keyType, sizeof(keyType)},
+        {CKA_VALUE, preMasterSecret, ulPreMasterSecretLen},
+        {CKA_SENSITIVE, &falseValue, sizeof(falseValue)},
+        {CKA_EXTRACTABLE, &falseValue, sizeof(falseValue)},
+        {CKA_DERIVE, &trueValue, sizeof(trueValue)},
+        {CKA_TOKEN, &falseValue, sizeof(falseValue)}
+    };
+    CK_ULONG ulBaseKeyTemplateCount =
+        sizeof(baseKeyTemplate) / sizeof(CK_ATTRIBUTE);
+
+    CK_TLS12_MASTER_KEY_DERIVE_PARAMS params;
+    params.RandomInfo.pClientRandom = clientRandom;
+    params.RandomInfo.ulClientRandomLen = sizeof(clientRandom);
+    params.RandomInfo.pServerRandom = serverRandom;
+    params.RandomInfo.ulServerRandomLen = sizeof(serverRandom);
+    /* Version for TLS 1.2 is {3, 3} */
+    CK_VERSION version = {3, 3};
+    params.pVersion = &version;
+    params.prfHashMechanism = CKM_SHA256;
+    CK_MECHANISM mechanism = {
+        CKM_TLS12_MASTER_KEY_DERIVE, &params, sizeof(params)
+    };
+
+    CK_ULONG derivedKeyLength = 48;
+    CK_KEY_TYPE derivedKeyType = CKK_GENERIC_SECRET;
+
+    CK_ATTRIBUTE derivedKeyTemplate[] = {
+        {CKA_CLASS, &keyClass, sizeof(keyClass)},
+        {CKA_KEY_TYPE, &derivedKeyType, sizeof(derivedKeyType)},
+        {CKA_SENSITIVE, &falseValue, sizeof(falseValue)},
+        {CKA_EXTRACTABLE, &trueValue, sizeof(trueValue)},
+        {CKA_DERIVE, &trueValue, sizeof(trueValue)},
+        {CKA_ENCRYPT, &falseValue, sizeof(falseValue)},
+        {CKA_DECRYPT, &falseValue, sizeof(falseValue)},
+        {CKA_TOKEN, &falseValue, sizeof(falseValue)},
+        {CKA_VALUE_LEN, &derivedKeyLength, sizeof(derivedKeyLength)}
+    };
+    CK_ULONG ulDerivedKeyTemplateCount =
+        sizeof(derivedKeyTemplate) / sizeof(CK_ATTRIBUTE);
+
+    CK_BYTE derivedKeyValue[48];
+    CK_ATTRIBUTE getValueTemplate[] = {
+        {CKA_VALUE, derivedKeyValue, sizeof(derivedKeyValue)}
+    };
+    CK_ULONG ulGetValueTemplateCount =
+        sizeof(getValueTemplate) / sizeof(CK_ATTRIBUTE);
+
+
+    ret = funcList->C_CreateObject(session, baseKeyTemplate,
+                                   ulBaseKeyTemplateCount, &hBaseKey);
+    CHECK_CKR(ret, "Base key");
+
+    if (ret == CKR_OK) {
+        version.major = 2;
+        ret = funcList->C_DeriveKey(session, &mechanism, hBaseKey,
+                                    derivedKeyTemplate,
+                                    ulDerivedKeyTemplateCount, &hDerivedKey);
+        CHECK_CKR_FAIL(ret, CKR_MECHANISM_INVALID, "Invalid version");
+        version.major = 3;
+    }
+
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_DeriveKey(session, &mechanism, hBaseKey,
+                                    derivedKeyTemplate,
+                                    ulDerivedKeyTemplateCount, &hDerivedKey);
+        CHECK_CKR(ret, "Derive key");
+    }
+
+    if (ret == CKR_OK) {
+        ret = funcList->C_GetAttributeValue(session, hDerivedKey,
+                                            getValueTemplate,
+                                            ulGetValueTemplateCount);
+    }
+    if (ret == CKR_OK) {
+        CHECK_COND(getValueTemplate[0].ulValueLen == ulExpectedMasterSecretLen,
+                   ret, "Derived key length mismatch");
+    }
+    if (ret == CKR_OK) {
+        CHECK_COND(getValueTemplate[0].ulValueLen != (CK_ULONG)-1, ret,
+                   "Get CKA_VALUE");
+    }
+
+    if (ret == CKR_OK) {
+        CHECK_COND(XMEMCMP(derivedKeyValue, expectedMasterSecret,
+                           ulExpectedMasterSecretLen) == 0, ret,
+                   "Secret compare");
+    }
+
+    return ret;
+}
+#endif
 
 static CK_RV pkcs11_lib_init(void)
 {
@@ -11358,7 +11841,9 @@ static TEST_FUNC testFunc[] = {
     PKCS11TEST_FUNC_SESS_DECL(test_aes_wrap_unwrap_pad_key),
 #endif
     PKCS11TEST_FUNC_SESS_DECL(test_wrap_unwrap_key),
+#ifndef NO_DH
     PKCS11TEST_FUNC_SESS_DECL(test_derive_key),
+#endif
 #ifndef NO_RSA
     PKCS11TEST_FUNC_SESS_DECL(test_rsa_fixed_keys_raw),
     PKCS11TEST_FUNC_SESS_DECL(test_rsa_fixed_keys_pkcs15_enc),
@@ -11507,6 +11992,11 @@ static TEST_FUNC testFunc[] = {
 #endif
     PKCS11TEST_FUNC_SESS_DECL(test_random),
     PKCS11TEST_FUNC_SESS_DECL(test_x509),
+#ifdef WOLFSSL_HAVE_PRF
+    PKCS11TEST_FUNC_SESS_DECL(test_derive_tls12_master_key_dh),
+    PKCS11TEST_FUNC_SESS_DECL(test_derive_tls12_key_and_mac),
+    PKCS11TEST_FUNC_SESS_DECL(test_derive_tls12_master_key),
+#endif
 };
 static int testFuncCnt = sizeof(testFunc) / sizeof(*testFunc);
 

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -421,6 +421,12 @@ int WP11_Tls12_Master_Key_Derive(CK_SSL3_RANDOM_DATA* random,
                                  CK_ULONG encLen, CK_BBOOL clientFirst,
                                  WP11_Object* key);
 
+int WP11_Nss_Tls12_Master_Key_Derive(CK_BYTE_PTR pSessionHash,
+                                     CK_ULONG ulSessionHashLen,
+                                     CK_MECHANISM_TYPE mech, const char* label,
+                                     CK_ULONG ulLabelLen, byte* enc,
+                                     CK_ULONG encLen, WP11_Object* key);
+
 int WP11_AesGenerateKey(WP11_Object* secret, WP11_Slot* slot);
 
 int WP11_AesCbc_DeriveKey(unsigned char* plain, word32 plainSz,

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -415,6 +415,14 @@ int WP11_GenerateRandomKey(WP11_Object* secret, WP11_Slot* slot);
 int WP11_KDF_Derive(WP11_Session* session, CK_HKDF_PARAMS_PTR params,
                     unsigned char* key, word32* keyLen, WP11_Object* priv);
 
+int WP11_Tls12_Master_Key_Derive(CK_SSL3_RANDOM_DATA* random,
+                                 CK_MECHANISM_TYPE mech, const char* label,
+                                 CK_ULONG ulLabelLen, byte* enc,
+                                 CK_ULONG encLen, CK_BBOOL clientFirst,
+                                 WP11_Object* key);
+
+int WP11_AesGenerateKey(WP11_Object* secret, WP11_Slot* slot);
+
 int WP11_AesCbc_DeriveKey(unsigned char* plain, word32 plainSz,
                         unsigned char* enc, byte* iv,
                         WP11_Object* key);

--- a/wolfpkcs11/pkcs11.h
+++ b/wolfpkcs11/pkcs11.h
@@ -273,6 +273,14 @@ extern "C" {
 #define CKM_HKDF_DERIVE                       0x0000402AUL
 #define CKM_HKDF_DATA                         0x0000402BUL
 #define CKM_HKDF_KEY_GEN                      0x0000402CUL
+#define CKM_VENDOR_DEFINED                    0x80000000UL
+
+#ifdef WOLFPKCS11_NSS
+#define CK_VENDOR_NSS                         0x4E534350UL
+#define CKM_NSS (CKM_VENDOR_DEFINED | CK_VENDOR_NSS)
+#define CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE    (CKM_NSS + 25)
+#define CKM_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_DH (CKM_NSS + 26)
+#endif
 
 #define CKR_OK                                0x00000000UL
 #define CKR_CANCEL                            0x00000001UL
@@ -656,6 +664,15 @@ typedef struct CK_TLS12_KEY_MAT_PARAMS {
     CK_SSL3_KEY_MAT_OUT_PTR pReturnedKeyMaterial;
     CK_MECHANISM_TYPE prfHashMechanism;
 } CK_TLS12_KEY_MAT_PARAMS;
+
+#ifdef WOLFPKCS11_NSS
+typedef struct CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS {
+    CK_MECHANISM_TYPE prfHashMechanism;
+    CK_BYTE_PTR pSessionHash;
+    CK_ULONG ulSessionHashLen;
+    CK_VERSION_PTR pVersion;
+} CK_NSS_TLS_EXTENDED_MASTER_KEY_DERIVE_PARAMS;
+#endif
 
 /* Function list types. */
 typedef struct CK_FUNCTION_LIST CK_FUNCTION_LIST;

--- a/wolfpkcs11/pkcs11.h
+++ b/wolfpkcs11/pkcs11.h
@@ -245,6 +245,9 @@ extern "C" {
 #define CKM_SHA3_512                          0x000002D0UL
 #define CKM_SHA3_512_HMAC                     0x000002D1UL
 #define CKM_GENERIC_SECRET_KEY_GEN            0x00000350UL
+#define CKM_TLS12_MASTER_KEY_DERIVE           0x000003E0UL
+#define CKM_TLS12_KEY_AND_MAC_DERIVE          0x000003E1UL
+#define CKM_TLS12_MASTER_KEY_DERIVE_DH        0x000003E2UL
 #define CKM_EC_KEY_PAIR_GEN                   0x00001040UL
 #define CKM_ECDSA                             0x00001041UL
 #define CKM_ECDSA_SHA1                        0x00001042UL
@@ -619,6 +622,40 @@ typedef struct CK_CCM_PARAMS {
 } CK_CCM_PARAMS;
 typedef CK_CCM_PARAMS* CK_CCM_PARAMS_PTR;
 
+typedef struct CK_SSL3_RANDOM_DATA {
+    CK_BYTE_PTR pClientRandom;
+    CK_ULONG ulClientRandomLen;
+    CK_BYTE_PTR pServerRandom;
+    CK_ULONG ulServerRandomLen;
+} CK_SSL3_RANDOM_DATA;
+
+typedef struct CK_TLS12_MASTER_KEY_DERIVE_PARAMS {
+    CK_SSL3_RANDOM_DATA RandomInfo;
+    CK_VERSION_PTR pVersion;
+    CK_MECHANISM_TYPE prfHashMechanism;
+} CK_TLS12_MASTER_KEY_DERIVE_PARAMS;
+typedef CK_TLS12_MASTER_KEY_DERIVE_PARAMS*
+    CK_TLS12_MASTER_KEY_DERIVE_PARAMS_PTR;
+
+typedef struct CK_SSL3_KEY_MAT_OUT {
+    CK_OBJECT_HANDLE hClientMacSecret;
+    CK_OBJECT_HANDLE hServerMacSecret;
+    CK_OBJECT_HANDLE hClientKey;
+    CK_OBJECT_HANDLE hServerKey;
+    CK_BYTE_PTR pIVClient;
+    CK_BYTE_PTR pIVServer;
+} CK_SSL3_KEY_MAT_OUT;
+typedef CK_SSL3_KEY_MAT_OUT* CK_SSL3_KEY_MAT_OUT_PTR;
+
+typedef struct CK_TLS12_KEY_MAT_PARAMS {
+    CK_ULONG ulMacSizeInBits;
+    CK_ULONG ulKeySizeInBits;
+    CK_ULONG ulIVSizeInBits;
+    CK_BBOOL bIsExport; /* Always CK_FALSE. */
+    CK_SSL3_RANDOM_DATA RandomInfo;
+    CK_SSL3_KEY_MAT_OUT_PTR pReturnedKeyMaterial;
+    CK_MECHANISM_TYPE prfHashMechanism;
+} CK_TLS12_KEY_MAT_PARAMS;
 
 /* Function list types. */
 typedef struct CK_FUNCTION_LIST CK_FUNCTION_LIST;


### PR DESCRIPTION
This implements the following mechanisms into `C_DeriveKey`:

* `CKM_TLS12_KEY_AND_MAC_DERIVE`
* `CKM_TLS12_MASTER_KEY_DERIVE`
* `CKM_TLS12_MASTER_KEY_DERIVE_DH`