### PR TITLE
Fix RSA with no public exponent

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -4523,4 +4523,3 @@ CK_RV C_GenerateRandom(CK_SESSION_HANDLE hSession,
 
     return CKR_OK;
 }
-

--- a/src/internal.c
+++ b/src/internal.c
@@ -5597,8 +5597,15 @@ int WP11_Object_SetRsaKey(WP11_Object* object, unsigned char** data,
            ret = SetMPI(&key->dQ, data[5], (int)len[5]);
         if (ret == 0)
            ret = SetMPI(&key->u, data[6], (int)len[6]);
-        if (ret == 0)
-           ret = SetMPI(&key->e, data[7], (int)len[7]);
+        if (ret == 0) {
+            /* Public exponent defaults to 65537 in PKCS11 > 2.11 */
+            if (len[7] > 0)
+                ret = SetMPI(&key->e, data[7], (int)len[7]);
+            else {
+                byte defaultPublic[] = {0x01, 0x00, 0x01};
+                ret = SetMPI(&key->e, defaultPublic, sizeof(defaultPublic));
+            }
+        }
         if (ret == 0) {
            if (len[8] == sizeof(CK_ULONG))
                object->size = (word32)*(CK_ULONG*)data[8];

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -442,5 +442,3 @@ int WP11_Slot_GenerateRandom(WP11_Slot* slot, unsigned char* data, int len);
 
 
 #endif /* WOLFPKCS11_INTERNAL_H */
-
-


### PR DESCRIPTION
When no public exponent is provided, we should use 65537. If we do not, when the key is loaded from the token during pin login, the ASN decode of the key will fail. This in-turn causes login to fail.

ZD 19876