### PR TITLE
Misc fixes for Firefox

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -5389,6 +5389,9 @@ CK_RV C_GenerateKey(CK_SESSION_HANDLE hSession,
             keyType = CKK_HKDF;
             break;
 #endif
+        case CKM_GENERIC_SECRET_KEY_GEN:
+            keyType = CKK_GENERIC_SECRET;
+            break;
         default:
             rv = CKR_MECHANISM_INVALID;
             break;

--- a/src/internal.c
+++ b/src/internal.c
@@ -90,7 +90,9 @@
 #define WP11_MAX_DH_KEY_SZ             (4096/8)
 
 /* Maximum size of storage for generated/derived symmetric key. */
-#ifndef NO_DH
+#ifdef WOLFPKCS11_NSS
+#define WP11_MAX_SYM_KEY_SZ            (2048)
+#elif !defined(NO_DH)
 #define WP11_MAX_SYM_KEY_SZ            (4096/8)
 #elif defined(HAVE_ECC)
 #define WP11_MAX_SYM_KEY_SZ            ((521+7)/8)
@@ -2970,13 +2972,17 @@ static int wp11_Object_Store_DhKey(WP11_Object* object, int tokenId, int objId)
  */
 static int wp11_Object_Decode_SymmKey(WP11_Object* object)
 {
-    int ret;
+    int ret = 0;
 
-    ret = wp11_DecryptData(object->data.symmKey.data, object->keyData,
+    if (object->keyDataLen - AES_BLOCK_SIZE > WP11_MAX_SYM_KEY_SZ)
+        ret = BUFFER_E;
+    if (ret == 0) {
+        ret = wp11_DecryptData(object->data.symmKey.data, object->keyData,
                                     object->keyDataLen - AES_BLOCK_SIZE,
                                     object->slot->token.key,
                                     sizeof(object->slot->token.key), object->iv,
                                     sizeof(object->iv));
+    }
     if (ret == 0)
         object->data.symmKey.len = object->keyDataLen - AES_BLOCK_SIZE;
     object->encoded = (ret != 0);
@@ -6293,9 +6299,11 @@ int WP11_Object_SetSecretKey(WP11_Object* object, unsigned char** data,
     if (ret == 0 && data[1] != NULL) {
         if (key->len == 0)
             key->len = (word32)len[1];
-        else if (len[1] < (CK_ULONG)key->len)
+        else if (len[1] != (CK_ULONG)key->len)
             ret = BUFFER_E;
     }
+    if (ret == 0 && key->len > WP11_MAX_SYM_KEY_SZ)
+        ret = BUFFER_E;
     if (ret == 0 && data[1] != NULL)
         XMEMCPY(key->data, data[1], key->len);
 

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -63,7 +63,11 @@ extern "C" {
 
 /* Maximum number of sessions allocated per slot/token. */
 #ifndef WP11_SESSION_CNT_MAX
+#ifdef WOLFPKCS11_NSS
+#define WP11_SESSION_CNT_MAX           7000
+#else
 #define WP11_SESSION_CNT_MAX           70
+#endif
 #endif
 /* Minimum number of sessions allocated per slot/token. */
 #ifndef WP11_SESSION_CNT_MIN
@@ -77,7 +81,7 @@ extern "C" {
 /* Maximum number of objects in a session. */
 #ifndef WP11_SESSION_OBJECT_CNT_MAX
 #ifdef WOLFPKCS11_NSS
-#define WP11_SESSION_OBJECT_CNT_MAX    64
+#define WP11_SESSION_OBJECT_CNT_MAX    6400
 #else
 #define WP11_SESSION_OBJECT_CNT_MAX    8
 #endif

--- a/wolfpkcs11/pkcs11.h
+++ b/wolfpkcs11/pkcs11.h
@@ -245,6 +245,7 @@ extern "C" {
 #define CKM_SHA3_512                          0x000002D0UL
 #define CKM_SHA3_512_HMAC                     0x000002D1UL
 #define CKM_GENERIC_SECRET_KEY_GEN            0x00000350UL
+#define CKM_SSL3_MASTER_KEY_DERIVE            0x00000371UL
 #define CKM_TLS_PRF                           0x00000378UL
 #define CKM_TLS12_MASTER_KEY_DERIVE           0x000003E0UL
 #define CKM_TLS12_KEY_AND_MAC_DERIVE          0x000003E1UL


### PR DESCRIPTION
- Advertise CKM_SSL3_MASTER_KEY_DERIVE even though we don't implement it. It is used by NSS to initially choose a slot that can support TLS resumption even though later the correct (TLS >=1.2) key derivation mechanism is selected. The relevant code is in `tls13_RecoverWrappedSharedSecret`.
- Increase `WP11_SESSION_OBJECT_CNT_MAX` and `WP11_SESSION_CNT_MAX`
- Advertise `CKF_USER_PIN_INITIALIZED` since we don't require login for NSS
- Add CKM_GENERIC_SECRET_KEY_GEN
- C_Login: accept a zero length pin
- Increase `WP11_MAX_SYM_KEY_SZ` and add size checks
