### PR TITLE
Add issuer, subject and serial to objects

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -122,8 +122,6 @@ static CK_ATTRIBUTE_TYPE trustParams[] = {
     CKA_TRUST_EMAIL_PROTECTION,
     CKA_TRUST_CODE_SIGNING,
     CKA_TRUST_STEP_UP_APPROVED,
-    CKA_ISSUER,
-    CKA_SERIAL_NUMBER,
 };
 #define TRUST_PARAMS_CNT    (sizeof(trustParams)/sizeof(*trustParams))
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -174,10 +174,6 @@ typedef struct WP11_Trust {
     CK_ULONG emailProtection;
     CK_ULONG codeSigning;
     CK_BBOOL stepUpApproved;
-    byte* issuer;                      /* Certificate issuer                  */
-    int issuerLen;                     /* Length of certificate issuer        */
-    byte* serial;                      /* Certificate serial number           */
-    int serialLen;                     /* Length of certificate serial number */
 } WP11_Trust;
 
 #ifndef NO_DH
@@ -234,6 +230,12 @@ struct WP11_Object {
     int keyIdLen;                      /* Length of key identifier            */
     unsigned char* label;              /* Object label                        */
     int labelLen;                      /* Length of object label              */
+    unsigned char* issuer;             /* Certificate issuer                  */
+    int issuerLen;                     /* Length of certificate issuer        */
+    unsigned char* serial;             /* Certificate serial number           */
+    int serialLen;                     /* Length of certificate serial number */
+    unsigned char* subject;            /* Subject of the object               */
+    int subjectLen;                    /* Length of subject                   */
 
     WP11_Lock* lock;                   /* Object specific lock                */
 
@@ -821,7 +823,10 @@ static int wolfPKCS11_Store_GetMaxSize(int type, int variableSz)
                 FIELD_SIZE(WP11_Object, endDate) +
                 sizeof(word32) + /* keyIdLenSz */
                 sizeof(word32) + /* labelLen */
-                variableSz /* keyIdLen + labelLen */
+                sizeof(word32) + /* issuerLen */
+                sizeof(word32) + /* serialLen */
+                sizeof(word32) + /* subjectLen */
+                variableSz /* keyIdLen + labelLen + issuerLen + serialLen + issuerLen + serialLen + subjectLen */
             ;
             break;
         case WOLFPKCS11_STORE_SYMMKEY:
@@ -832,6 +837,7 @@ static int wolfPKCS11_Store_GetMaxSize(int type, int variableSz)
         case WOLFPKCS11_STORE_DHKEY_PRIV:
         case WOLFPKCS11_STORE_DHKEY_PUB:
         case WOLFPKCS11_STORE_CERT:
+        case WOLFPKCS11_STORE_TRUST:
             maxSz = sizeof(word32) + variableSz;
             break;
 
@@ -1786,6 +1792,38 @@ static int wp11_DecryptData(byte* out, byte* data, int len, byte* key,
 }
 
 /**
+ * "Decode" the certificate.
+ *
+ * Certificates are not encrypted.
+ *
+ * @param [in, out]  object  Certificate object.
+ */
+static void wp11_Object_Decode_Cert(WP11_Object* object)
+{
+    if (object->data.cert.data == NULL) {
+        object->data.cert.data = object->keyData;
+        object->data.cert.len = object->keyDataLen;
+    }
+    object->encoded = 0;
+}
+
+#ifdef WOLFPKCS11_NSS
+/**
+ * "Decode" the trust.
+ *
+ * Trust is not encrypted.
+ *
+ * @param [in, out]  object  Trust object.
+ */
+static void wp11_Object_Decode_Trust(WP11_Object* object)
+{
+    XMEMCPY((unsigned char*)&object->data.trust, object->keyData,
+        object->keyDataLen);
+    object->encoded = 0;
+}
+#endif
+
+/**
  * Load a certificate from storage.
  *
  * @param [in, out]  object   Certificate object.
@@ -1809,10 +1847,45 @@ static int wp11_Object_Load_Cert(WP11_Object* object, int tokenId, int objId)
         ret = wp11_storage_read_alloc_array(storage, &object->keyData,
             &object->keyDataLen);
         wp11_storage_close(storage);
+        /* Decode without login needed */
+        wp11_Object_Decode_Cert(object);
     }
 
     return ret;
 }
+
+#ifdef WOLFPKCS11_NSS
+/**
+ * Load trust object from storage.
+ *
+ * @param [in, out]  object   Trust object.
+ * @param [in]       tokenId  Id of token this cert belongs to.
+ * @param [in]       objId    Id of object for token.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ * @return  BUFFER_E when loading fails.
+ * @return  NOT_AVAILABLE_E when unable to locate data.
+ */
+static int wp11_Object_Load_Trust(WP11_Object* object, int tokenId, int objId)
+{
+    int ret;
+    void* storage = NULL;
+
+    /* Open access to trust. */
+    ret = wp11_storage_open_readonly(WOLFPKCS11_STORE_TRUST, tokenId, objId,
+        &storage);
+    if (ret == 0) {
+        /* Read trust. */
+        ret = wp11_storage_read_alloc_array(storage, &object->keyData,
+            &object->keyDataLen);
+        wp11_storage_close(storage);
+        wp11_Object_Decode_Trust(object);
+    }
+
+    return ret;
+}
+#endif
+
 
 #ifdef WOLFSSL_MAXQ10XX_CRYPTO
 #ifdef MAXQ10XX_PRODUCTION_KEY
@@ -2121,21 +2194,36 @@ exit:
     return ret;
 }
 
+#ifdef WOLFPKCS11_NSS
 /**
- * "Decode" the certificate.
+ * Store an trust object to storage.
  *
- * Certificates are not encrypted.
- *
- * @param [in, out]  object  Certificate object.
+ * @param [in]  object   Trust object.
+ * @param [in]  tokenId  Id of token this cert belongs to.
+ * @param [in]  objId    Id of object for token.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ * @return  BUFFER_E when storing fails.
+ * @return  NOT_AVAILABLE_E when unable to write data.
  */
-static void wp11_Object_Decode_Cert(WP11_Object* object)
+static int wp11_Object_Store_Trust(WP11_Object* object, int tokenId, int objId)
 {
-    if (object->data.cert.data == NULL) {
-        object->data.cert.data = object->keyData;
-        object->data.cert.len = object->keyDataLen;
+    int ret;
+    void* storage = NULL;
+
+    /* Open access to trust. */
+    ret = wp11_storage_open(WOLFPKCS11_STORE_TRUST, tokenId, objId,
+        sizeof(WP11_Trust), &storage);
+    if (ret == 0) {
+        /* Write trust to storage. */
+        ret = wp11_storage_write_array(storage,
+            (unsigned char*)&object->data.trust, sizeof(WP11_Trust));
+        wp11_storage_close(storage);
     }
-    object->encoded = 0;
+
+    return ret;
 }
+#endif /* WOLFPKCS11_NSS */
 
 #ifndef NO_RSA
 /**
@@ -3172,6 +3260,21 @@ static int wp11_Object_Load_Object(WP11_Object* object, int tokenId, int objId)
             ret = wp11_storage_read_alloc_array(storage, &object->label,
                                                 &object->labelLen);
         }
+        if (ret == 0) {
+            /* Read issuer of the object. (variable issuerLen) */
+            ret = wp11_storage_read_alloc_array(storage, &object->issuer,
+                                                &object->issuerLen);
+        }
+        if (ret == 0) {
+            /* Read serial number of the object. (variable serialLen) */
+            ret = wp11_storage_read_alloc_array(storage, &object->serial,
+                                                &object->serialLen);
+        }
+        if (ret == 0) {
+            /* Read subject of the object. (variable subjectLen) */
+            ret = wp11_storage_read_alloc_array(storage, &object->subject,
+                                                &object->subjectLen);
+        }
 
         wp11_storage_close(storage);
     }
@@ -3198,6 +3301,12 @@ static int wp11_Object_Load(WP11_Object* object, int tokenId, int objId)
         if (object->objClass == CKO_CERTIFICATE) {
             ret = wp11_Object_Load_Cert(object, tokenId, objId);
         }
+#ifdef WOLFPKCS11_NSS
+        else if(object->objClass == CKO_NSS_TRUST) {
+            ret = wp11_Object_Load_Trust(object, tokenId, objId);
+        }
+#endif
+
         else {
             /* Load separate key data. */
             switch (object->type) {
@@ -3236,7 +3345,8 @@ static int wp11_Object_Store_Object(WP11_Object* object, int tokenId, int objId)
     int ret;
     void* storage = NULL;
     word32 dummy = 0;
-    int variableSz = (object->keyIdLen + object->labelLen);
+    int variableSz = (object->keyIdLen + object->labelLen +
+        object->issuerLen + object->serialLen + object->subjectLen);
 
     /* Open access to key object. */
     ret = wp11_storage_open(WOLFPKCS11_STORE_OBJECT, tokenId, objId, variableSz,
@@ -3294,6 +3404,21 @@ static int wp11_Object_Store_Object(WP11_Object* object, int tokenId, int objId)
             ret = wp11_storage_write_array(storage, object->label,
                                                               object->labelLen);
         }
+        if (ret == 0) {
+            /* Write issuer of the object. (variable issuerLen) */
+            ret = wp11_storage_write_array(storage, object->issuer,
+                                           object->issuerLen);
+        }
+        if (ret == 0) {
+            /* Write serial of the object. (variable serialLen) */
+            ret = wp11_storage_write_array(storage, object->serial,
+                                           object->serialLen);
+        }
+        if (ret == 0) {
+            /* Write subject of the object. (variable subjectLen) */
+            ret = wp11_storage_write_array(storage, object->subject,
+                                           object->subjectLen);
+        }
 
         wp11_storage_close(storage);
     }
@@ -3330,6 +3455,11 @@ static int wp11_Object_Store(WP11_Object* object, int tokenId, int objId)
         if (object->objClass == CKO_CERTIFICATE) {
             ret = wp11_Object_Store_Cert(object, tokenId, objId);
         }
+#ifdef WOLFPKCS11_NSS
+        else if (object->objClass == CKO_NSS_TRUST) {
+            ret = wp11_Object_Store_Trust(object, tokenId, objId);
+        }
+#endif
         else {
             /* Store key data separately. */
             switch (object->type) {
@@ -3381,6 +3511,12 @@ static int wp11_Object_Decode(WP11_Object* object)
         wp11_Object_Decode_Cert(object);
         ret = 0;
     }
+#ifdef WOLFPKCS11_NSS
+    else if (object->objClass == CKO_NSS_TRUST) {
+        wp11_Object_Decode_Trust(object);
+        ret = 0;
+    }
+#endif
     else {
         switch (object->type) {
         #ifndef NO_RSA
@@ -5898,10 +6034,10 @@ void WP11_Object_Free(WP11_Object* object)
     }
     #ifdef WOLFPKCS11_NSS
     else if (object->objClass == CKO_NSS_TRUST) {
-        if (object->data.trust.issuer != NULL)
-            XFREE(object->data.trust.issuer, NULL, DYNAMIC_TYPE_CERT);
-        if (object->data.trust.serial != NULL)
-            XFREE(object->data.trust.serial, NULL, DYNAMIC_TYPE_CERT);
+        if (object->issuer != NULL)
+            XFREE(object->issuer, NULL, DYNAMIC_TYPE_CERT);
+        if (object->serial != NULL)
+            XFREE(object->serial, NULL, DYNAMIC_TYPE_CERT);
     }
     #endif
     else {
@@ -6374,31 +6510,6 @@ int WP11_Object_SetTrust(WP11_Object* object, unsigned char** data,
     if (data[6] != NULL)
         trust->stepUpApproved = *(CK_BBOOL*)data[6];
 
-    if ((data[7] != NULL) && (len[7] != 0)) {
-        if (trust->issuer != NULL) {
-            XFREE(trust->issuer, NULL, DYNAMIC_TYPE_CERT);
-        }
-        trust->issuer = (byte *)XMALLOC(len[7], NULL,
-            DYNAMIC_TYPE_CERT);
-        if (trust->issuer == NULL) {
-            return MEMORY_E;
-        }
-        trust->issuerLen = len[7];
-        XMEMCPY(trust->issuer, data[7], trust->issuerLen);
-    }
-    if ((data[8] != NULL) && (len[8] != 0)) {
-        if (trust->serial != NULL) {
-            XFREE(trust->serial, NULL, DYNAMIC_TYPE_CERT);
-        }
-        trust->serial = (byte *)XMALLOC(len[8], NULL,
-            DYNAMIC_TYPE_CERT);
-        if (trust->serial == NULL) {
-            return MEMORY_E;
-        }
-        trust->serialLen = len[8];
-        XMEMCPY(trust->serial, data[8], trust->serialLen);
-    }
-
     if (object->onToken)
         WP11_Lock_UnlockRW(object->lock);
 
@@ -6708,12 +6819,10 @@ static int GetTrustAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
                 ret = GetBool(object->data.trust.stepUpApproved, data, len);
             break;
         case CKA_ISSUER:
-            ret = GetData(object->data.trust.issuer,
-                object->data.trust.issuerLen, data, len);
+            ret = GetData(object->issuer, object->issuerLen, data, len);
             break;
         case CKA_SERIAL_NUMBER:
-            ret = GetData(object->data.trust.serial,
-                object->data.trust.serialLen, data, len);
+            ret = GetData(object->serial, object->serialLen, data, len);
             break;
         default:
             ret = NOT_AVAILABLE_E;
@@ -7079,6 +7188,9 @@ int WP11_Object_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
         case CKA_LABEL:
             ret = GetData(object->label, object->labelLen, data, len);
             break;
+        case CKA_SUBJECT:
+            ret = GetData(object->subject, object->subjectLen, data, len);
+            break;
         case CKA_TOKEN:
             ret = GetBool(object->onToken, data, len);
             break;
@@ -7183,10 +7295,6 @@ int WP11_Object_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
             break;
         case CKA_DERIVE:
             ret = GetOpFlagBool(object->opFlag, WP11_FLAG_DERIVE, data, len);
-            break;
-
-        case CKA_SUBJECT:
-            ret = NOT_AVAILABLE_E;
             break;
 
         default:
@@ -7551,12 +7659,18 @@ int WP11_Object_SetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
             /* Handled in WP11_Object_SetCert */
             break;
         case CKA_ISSUER:
-            /* Handled in WP11_Object_SetTrust */
+            ret = WP11_Object_SetData(&object->issuer, &object->issuerLen,
+                                      data, (int)len);
             break;
         case CKA_SERIAL_NUMBER:
-            /* Handled in WP11_Object_SetTrust */
+            ret = WP11_Object_SetData(&object->serial, &object->serialLen,
+                                      data, (int)len);
             break;
         case CKA_SUBJECT:
+            ret = WP11_Object_SetData(&object->subject, &object->subjectLen,
+                                      data, (int)len);
+            break;
+
         case CKA_AC_ISSUER:
         case CKA_ATTR_TYPES:
         case CKA_CERTIFICATE_CATEGORY:

--- a/tests/pkcs11mtt.c
+++ b/tests/pkcs11mtt.c
@@ -711,7 +711,6 @@ static CK_RV test_attribute_types(void* args)
         { CKA_WRAP_TEMPLATE,       NULL,                0                     },
         { CKA_UNWRAP_TEMPLATE,     NULL,                0                     },
         { CKA_ALLOWED_MECHANISMS,  NULL,                0                     },
-        { CKA_SUBJECT,             NULL,                0                     },
     };
     CK_ULONG badAttrsTmplCnt = sizeof(badAttrsTmpl) / sizeof(*badAttrsTmpl);
     CK_DATE startDate = { "2018", "01", "01" };

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -1118,6 +1118,254 @@ static CK_RV test_op_state_success(void* args)
 }
 #endif
 
+#ifdef WOLFPKCS11_NSS
+/* Test creating a token stored CKO_NSS_TRUST object, closing session,
+ * reopening session, logging in, and verifying persistence */
+static CK_RV test_nss_trust_object_token_storage(void* args)
+{
+    CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
+    CK_SESSION_HANDLE newSession = CK_INVALID_HANDLE;
+    CK_RV ret = CKR_OK;
+    CK_OBJECT_HANDLE obj = CK_INVALID_HANDLE;
+    CK_OBJECT_CLASS nss_trust_class = CKO_NSS_TRUST;
+    int rwFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+
+    /* Values for attributes */
+    static byte issuer[] = "CN=Token Test Signer,O=wolfSSL,C=US";
+    static byte serial_number[] = { 0x02, 0x05, 0x00, 0xC6, 0xA7, 0x91, 0x85 };
+    static byte sha1_hash[] = {
+        0x01, 0x75, 0x85, 0x74, 0xF9, 0xD2, 0x3D, 0x09,
+        0x74, 0x5B, 0x1A, 0x72, 0xBA, 0xA6, 0xCC, 0x15,
+        0xF1, 0xD0, 0x7A, 0x37
+    };
+    static byte md5_hash[] = {
+        0x48, 0xC3, 0x68, 0x9D, 0xB0, 0xEA, 0x15, 0x22,
+        0xD3, 0xE6, 0xA1, 0x7D, 0x84, 0xA0, 0x8E, 0xEC
+    };
+    static byte label[] = "TokenTrustTest";
+    CK_ULONG trust_value = 0xCE534353;
+    CK_BBOOL step_up = CK_FALSE;
+
+    /* Template for creating the token object */
+    CK_ATTRIBUTE tmpl[] = {
+        { CKA_TOKEN, &ckTrue, sizeof(ckTrue) },
+        { CKA_CLASS, &nss_trust_class, sizeof(nss_trust_class) },
+        { CKA_LABEL, label, sizeof(label)-1 },
+        { CKA_ISSUER, issuer, sizeof(issuer)-1 },
+        { CKA_SERIAL_NUMBER, serial_number, sizeof(serial_number) },
+        { CKA_CERT_SHA1_HASH, sha1_hash, sizeof(sha1_hash) },
+        { CKA_CERT_MD5_HASH, md5_hash, sizeof(md5_hash) },
+        { CKA_TRUST_SERVER_AUTH, &trust_value, sizeof(trust_value) },
+        { CKA_TRUST_CLIENT_AUTH, &trust_value, sizeof(trust_value) },
+        { CKA_TRUST_CODE_SIGNING, &trust_value, sizeof(trust_value) },
+        { CKA_TRUST_EMAIL_PROTECTION, &trust_value, sizeof(trust_value) },
+        { CKA_TRUST_STEP_UP_APPROVED, &step_up, sizeof(step_up) }
+    };
+    CK_ULONG tmplCnt = sizeof(tmpl) / sizeof(*tmpl);
+
+    /* Template for finding the object */
+    CK_ATTRIBUTE findTmpl[] = {
+        { CKA_CLASS, &nss_trust_class, sizeof(nss_trust_class) },
+        { CKA_LABEL, label, sizeof(label)-1 }
+    };
+    CK_ULONG findTmplCnt = sizeof(findTmpl) / sizeof(*findTmpl);
+
+    /* Buffer to retrieve attribute values */
+    CK_BYTE buffer[64];
+    CK_ATTRIBUTE getAttr;
+    CK_OBJECT_CLASS retClass;
+    CK_ULONG retTrustValue;
+    CK_BBOOL retBool;
+    CK_ULONG count;
+
+    /* Create the token stored NSS_TRUST object */
+    ret = funcList->C_CreateObject(session, tmpl, tmplCnt, &obj);
+    CHECK_CKR(ret, "Create Token NSS_TRUST Object");
+
+    /* Close the session */
+    if (ret == CKR_OK) {
+        if (userPinLen != 0)
+            funcList->C_Logout(session);
+        funcList->C_CloseSession(session);
+    }
+
+    /* Open a new session */
+    if (ret == CKR_OK) {
+        ret = funcList->C_OpenSession(slot, rwFlags, NULL, NULL, &newSession);
+        CHECK_CKR(ret, "Open New Session for Token Trust Test");
+    }
+
+    /* Login as user */
+    if (ret == CKR_OK && userPinLen != 0) {
+        ret = funcList->C_Login(newSession, CKU_USER, userPin, userPinLen);
+        CHECK_CKR(ret, "Login User for Token Trust Test");
+    }
+
+    /* Find the token object */
+    if (ret == CKR_OK) {
+        ret = funcList->C_FindObjectsInit(newSession, findTmpl, findTmplCnt);
+        CHECK_CKR(ret, "Find Token NSS_TRUST Objects Init");
+    }
+    if (ret == CKR_OK) {
+        ret = funcList->C_FindObjects(newSession, &obj, 1, &count);
+        CHECK_CKR(ret, "Find Token NSS_TRUST Objects");
+    }
+    if (ret == CKR_OK && count != 1) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object not found");
+    }
+    if (ret == CKR_OK) {
+        ret = funcList->C_FindObjectsFinal(newSession);
+        CHECK_CKR(ret, "Find Token NSS_TRUST Objects Final");
+    }
+
+    /* Verify object class */
+    if (ret == CKR_OK) {
+        getAttr.type = CKA_CLASS;
+        getAttr.pValue = &retClass;
+        getAttr.ulValueLen = sizeof(retClass);
+        ret = funcList->C_GetAttributeValue(newSession, obj, &getAttr, 1);
+        CHECK_CKR(ret, "Get Token NSS_TRUST Object class");
+    }
+    if (ret == CKR_OK && retClass != CKO_NSS_TRUST) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object class incorrect");
+    }
+
+    /* Verify ISSUER attribute */
+    if (ret == CKR_OK) {
+        getAttr.type = CKA_ISSUER;
+        getAttr.pValue = buffer;
+        getAttr.ulValueLen = sizeof(buffer);
+        ret = funcList->C_GetAttributeValue(newSession, obj, &getAttr, 1);
+        CHECK_CKR(ret, "Get Token NSS_TRUST Object issuer");
+    }
+    if (ret == CKR_OK && (getAttr.ulValueLen != sizeof(issuer)-1 ||
+            XMEMCMP(buffer, issuer, sizeof(issuer)-1) != 0)) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object issuer incorrect");
+    }
+
+    /* Verify SERIAL_NUMBER attribute */
+    if (ret == CKR_OK) {
+        getAttr.type = CKA_SERIAL_NUMBER;
+        getAttr.pValue = buffer;
+        getAttr.ulValueLen = sizeof(buffer);
+        ret = funcList->C_GetAttributeValue(newSession, obj, &getAttr, 1);
+        CHECK_CKR(ret, "Get Token NSS_TRUST Object serial number");
+    }
+    if (ret == CKR_OK && (getAttr.ulValueLen != sizeof(serial_number) ||
+            XMEMCMP(buffer, serial_number, sizeof(serial_number)) != 0)) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object serial number incorrect");
+    }
+
+    /* Verify SHA1_HASH attribute */
+    if (ret == CKR_OK) {
+        getAttr.type = CKA_CERT_SHA1_HASH;
+        getAttr.pValue = buffer;
+        getAttr.ulValueLen = sizeof(buffer);
+        ret = funcList->C_GetAttributeValue(newSession, obj, &getAttr, 1);
+        CHECK_CKR(ret, "Get Token NSS_TRUST Object SHA1 hash");
+    }
+    if (ret == CKR_OK && (getAttr.ulValueLen != sizeof(sha1_hash) ||
+            XMEMCMP(buffer, sha1_hash, sizeof(sha1_hash)) != 0)) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object SHA1 hash incorrect");
+    }
+
+    /* Verify MD5_HASH attribute */
+    if (ret == CKR_OK) {
+        getAttr.type = CKA_CERT_MD5_HASH;
+        getAttr.pValue = buffer;
+        getAttr.ulValueLen = sizeof(buffer);
+        ret = funcList->C_GetAttributeValue(newSession, obj, &getAttr, 1);
+        CHECK_CKR(ret, "Get Token NSS_TRUST Object MD5 hash");
+    }
+    if (ret == CKR_OK && (getAttr.ulValueLen != sizeof(md5_hash) ||
+            XMEMCMP(buffer, md5_hash, sizeof(md5_hash)) != 0)) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object MD5 hash incorrect");
+    }
+
+    /* Verify TRUST_SERVER_AUTH attribute */
+    if (ret == CKR_OK) {
+        getAttr.type = CKA_TRUST_SERVER_AUTH;
+        getAttr.pValue = &retTrustValue;
+        getAttr.ulValueLen = sizeof(retTrustValue);
+        ret = funcList->C_GetAttributeValue(newSession, obj, &getAttr, 1);
+        CHECK_CKR(ret, "Get Token NSS_TRUST Object server auth");
+    }
+    if (ret == CKR_OK && retTrustValue != trust_value) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object server auth incorrect");
+    }
+
+    /* Verify TRUST_CLIENT_AUTH attribute */
+    if (ret == CKR_OK) {
+        getAttr.type = CKA_TRUST_CLIENT_AUTH;
+        getAttr.pValue = &retTrustValue;
+        getAttr.ulValueLen = sizeof(retTrustValue);
+        ret = funcList->C_GetAttributeValue(newSession, obj, &getAttr, 1);
+        CHECK_CKR(ret, "Get Token NSS_TRUST Object client auth");
+    }
+    if (ret == CKR_OK && retTrustValue != trust_value) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object client auth incorrect");
+    }
+
+    /* Verify TRUST_CODE_SIGNING attribute */
+    if (ret == CKR_OK) {
+        getAttr.type = CKA_TRUST_CODE_SIGNING;
+        getAttr.pValue = &retTrustValue;
+        getAttr.ulValueLen = sizeof(retTrustValue);
+        ret = funcList->C_GetAttributeValue(newSession, obj, &getAttr, 1);
+        CHECK_CKR(ret, "Get Token NSS_TRUST Object code signing");
+    }
+    if (ret == CKR_OK && retTrustValue != trust_value) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object code signing incorrect");
+    }
+
+    /* Verify TRUST_EMAIL_PROTECTION attribute */
+    if (ret == CKR_OK) {
+        getAttr.type = CKA_TRUST_EMAIL_PROTECTION;
+        getAttr.pValue = &retTrustValue;
+        getAttr.ulValueLen = sizeof(retTrustValue);
+        ret = funcList->C_GetAttributeValue(newSession, obj, &getAttr, 1);
+        CHECK_CKR(ret, "Get Token NSS_TRUST Object email protection");
+    }
+    if (ret == CKR_OK && retTrustValue != trust_value) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object email protection incorrect");
+    }
+
+    /* Verify TRUST_STEP_UP_APPROVED attribute */
+    if (ret == CKR_OK) {
+        getAttr.type = CKA_TRUST_STEP_UP_APPROVED;
+        getAttr.pValue = &retBool;
+        getAttr.ulValueLen = sizeof(retBool);
+        ret = funcList->C_GetAttributeValue(newSession, obj, &getAttr, 1);
+        CHECK_CKR(ret, "Get Token NSS_TRUST Object step up approved");
+    }
+    if (ret == CKR_OK && retBool != step_up) {
+        ret = -1;
+        CHECK_CKR(ret, "Token NSS_TRUST Object step up approved incorrect");
+    }
+
+    /* Destroy the token object */
+    if (ret == CKR_OK) {
+        ret = funcList->C_DestroyObject(newSession, obj);
+        CHECK_CKR(ret, "Destroy Token NSS_TRUST Object");
+    }
+
+    /* Update the session handle for cleanup */
+    *(CK_SESSION_HANDLE*)args = newSession;
+
+    return ret;
+}
+#endif
+
 static CK_RV test_op_state_fail(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
@@ -1696,7 +1944,6 @@ static CK_RV test_attribute_types(void* args)
         { CKA_WRAP_TEMPLATE,       NULL,                0                     },
         { CKA_UNWRAP_TEMPLATE,     NULL,                0                     },
         { CKA_ALLOWED_MECHANISMS,  NULL,                0                     },
-        { CKA_SUBJECT,             NULL,                0                     },
     };
     CK_ULONG badAttrsTmplCnt = sizeof(badAttrsTmpl) / sizeof(*badAttrsTmpl);
     CK_DATE startDate = { "2018", "01", "01" };
@@ -1711,6 +1958,24 @@ static CK_RV test_attribute_types(void* args)
         { CKA_LABEL,               emptyLabel,          sizeof(emptyLabel)    },
     };
     CK_ULONG setGetTmplCnt = sizeof(setGetTmpl) / sizeof(*setGetTmpl);
+
+    /* Certificate test variables */
+    CK_OBJECT_HANDLE certObj = CK_INVALID_HANDLE;
+    CK_CERTIFICATE_TYPE certType = CKC_X_509;
+    CK_BYTE subject[] = "C = US, ST = Montana, L = Bozeman, O = wolfSSL, "
+        "OU = Support, CN = www.wolfssl.com, emailAddress = info@wolfssl.com";
+    CK_BYTE certificate[] = { 0x30, 0x82, 0x01, 0x00 }; /* Minimal cert data */
+    CK_ATTRIBUTE certTmpl[] = {
+        { CKA_CLASS,             &certificateClass, sizeof(certificateClass) },
+        { CKA_CERTIFICATE_TYPE,  &certType,         sizeof(certType)         },
+        { CKA_SUBJECT,           subject,           sizeof(subject)-1        },
+        { CKA_VALUE,             certificate,       sizeof(certificate)      },
+    };
+    CK_ULONG certTmplCnt = sizeof(certTmpl) / sizeof(*certTmpl);
+    CK_BYTE subjectBuffer[256];
+    CK_ATTRIBUTE subjectAttr[] = {
+        { CKA_SUBJECT,             subjectBuffer,       sizeof(subjectBuffer)    },
+    };
     int i;
 
     ret = funcList->C_CreateObject(session, tmpl, tmplCnt, &obj);
@@ -1752,8 +2017,48 @@ static CK_RV test_attribute_types(void* args)
         CHECK_CKR(ret, "Get Empty data attributes");
     }
 
+    /* Test CKA_SUBJECT attribute with CKO_CERTIFICATE object
+     * This verifies that CKA_SUBJECT is properly supported for certificate objects
+     * and that the subject data can be retrieved correctly. */
+    if (ret == CKR_OK) {
+        ret = funcList->C_CreateObject(session, certTmpl, certTmplCnt,
+            &certObj);
+        CHECK_CKR(ret, "Create Certificate Object");
+    }
+    if (ret == CKR_OK) {
+        /* First get the required buffer size for CKA_SUBJECT */
+        subjectAttr[0].pValue = NULL;
+        subjectAttr[0].ulValueLen = 0;
+        ret = funcList->C_GetAttributeValue(session, certObj, subjectAttr, 1);
+        CHECK_CKR(ret, "Get CKA_SUBJECT length from certificate");
+    }
+    if (ret == CKR_OK) {
+        /* Verify the length matches our expected subject size */
+        if (subjectAttr[0].ulValueLen != sizeof(subject)-1) {
+            ret = CKR_GENERAL_ERROR;
+            CHECK_CKR(ret, "CKA_SUBJECT length verification");
+        }
+    }
+    if (ret == CKR_OK) {
+        /* Now get the actual CKA_SUBJECT data */
+        subjectAttr[0].pValue = subjectBuffer;
+        subjectAttr[0].ulValueLen = sizeof(subjectBuffer);
+        ret = funcList->C_GetAttributeValue(session, certObj, subjectAttr, 1);
+        CHECK_CKR(ret, "Get CKA_SUBJECT data from certificate");
+    }
+    if (ret == CKR_OK) {
+        /* Verify subject data matches what we set */
+        if (subjectAttr[0].ulValueLen != sizeof(subject)-1 ||
+            XMEMCMP(subjectAttr[0].pValue, subject, sizeof(subject)-1) != 0) {
+            ret = CKR_GENERAL_ERROR;
+            CHECK_CKR(ret, "CKA_SUBJECT data verification failed");
+        }
+    }
+
     if (obj != CK_INVALID_HANDLE)
         funcList->C_DestroyObject(session, obj);
+    if (certObj != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, certObj);
 
     return ret;
 }
@@ -12485,6 +12790,7 @@ static TEST_FUNC testFunc[] = {
     PKCS11TEST_FUNC_SESS_DECL(test_derive_tls12_master_key),
 #ifdef WOLFPKCS11_NSS
     PKCS11TEST_FUNC_SESS_DECL(test_nss_trust_object),
+    PKCS11TEST_FUNC_SESS_DECL(test_nss_trust_object_token_storage),
     PKCS11TEST_FUNC_SESS_DECL(test_nss_derive_tls12_master_key),
 #endif
 #endif

--- a/wolfpkcs11/store.h
+++ b/wolfpkcs11/store.h
@@ -32,6 +32,7 @@
 #define WOLFPKCS11_STORE_DHKEY_PRIV     0x07
 #define WOLFPKCS11_STORE_DHKEY_PUB      0x08
 #define WOLFPKCS11_STORE_CERT           0x09
+#define WOLFPKCS11_STORE_TRUST          0x0A
 
 /*
  * Opens access to location to read/write token data.
@@ -95,4 +96,3 @@ int wolfPKCS11_Store_Read(void* store, unsigned char* buffer, int len);
 int wolfPKCS11_Store_Write(void* store, unsigned char* buffer, int len);
 
 #endif /* WOLFPKCS11_STORE */
-


### PR DESCRIPTION
Both NSS trust and general certificates need these.

Also:
* Fix storage for these attributes.
* Fix storage for NSS trust objects.