### PR TITLE
Fixes for GCC 15.1

### DIFF
--- a/src/slot.c
+++ b/src/slot.c
@@ -105,7 +105,10 @@ static CK_TOKEN_INFO tokenInfoTemplate = {
     "",
     "wolfpkcs11",
     "wolfpkcs11",
-    "0000000000000000", /* serialNumber */
+    {
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    }, /* serialNumber */
     CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_LOGIN_REQUIRED,
     WP11_SESSION_CNT_MAX, /* ulMaxSessionCount */
     CK_UNAVAILABLE_INFORMATION, /* ulSessionCount */
@@ -119,7 +122,10 @@ static CK_TOKEN_INFO tokenInfoTemplate = {
     CK_UNAVAILABLE_INFORMATION, /* ulFreePrivateMemory */
     { WOLFPKCS11_MAJOR_VERSION, WOLFPKCS11_MINOR_VERSION },
     { WOLFPKCS11_MAJOR_VERSION, WOLFPKCS11_MINOR_VERSION },
-    "YYYYMMDDhhmmss00"
+    {
+        'Y', 'Y', 'Y', 'Y', 'M', 'M', 'D', 'D', 'h', 'h', 'm', 'm', 's', 's',
+        '0', '0'
+    }
 };
 
 /**
@@ -1067,4 +1073,3 @@ CK_RV C_WaitForSlotEvent(CK_FLAGS flags, CK_SLOT_ID_PTR pSlot,
 
     return CKR_FUNCTION_NOT_SUPPORTED;
 }
-

--- a/tests/pkcs11mtt.c
+++ b/tests/pkcs11mtt.c
@@ -722,11 +722,11 @@ static CK_RV test_attribute_types(void* args)
         { CKA_SUBJECT,             NULL,                0                     },
     };
     CK_ULONG badAttrsTmplCnt = sizeof(badAttrsTmpl) / sizeof(*badAttrsTmpl);
-    CK_DATE startDate = { "2018", "01", "01" };
-    CK_DATE endDate = { "2118", "01", "01" };
+    CK_DATE startDate = { {'2','0','1','8'}, {'0','1'}, {'0','1'} };
+    CK_DATE endDate = { {'2','1','1','8'}, {'0','1'}, {'0','1'} };
     CK_CHAR label[32] = "The Key's Label!!!";
-    CK_DATE emptyStartDate = { "2018", "01", "01" };
-    CK_DATE emptyEndDate = { "2118", "01", "01" };
+    CK_DATE emptyStartDate = { {'2','0','1','8'}, {'0','1'}, {'0','1'} };
+    CK_DATE emptyEndDate = { {'2','1','1','8'}, {'0','1'}, {'0','1'} };
     CK_CHAR emptyLabel[32] = "The Key's Label!!!";
     CK_ATTRIBUTE setGetTmpl[] = {
         { CKA_START_DATE,          &emptyStartDate,     sizeof(CK_DATE)       },

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -1562,11 +1562,11 @@ static CK_RV test_attribute_types(void* args)
         { CKA_SUBJECT,             NULL,                0                     },
     };
     CK_ULONG badAttrsTmplCnt = sizeof(badAttrsTmpl) / sizeof(*badAttrsTmpl);
-    CK_DATE startDate = { "2018", "01", "01" };
-    CK_DATE endDate = { "2118", "01", "01" };
+    CK_DATE startDate = { {'2','0','1','8'}, {'0','1'}, {'0','1'} };
+    CK_DATE endDate = { {'2','1','1','8'}, {'0','1'}, {'0','1'} };
     CK_CHAR label[32] = "The Key's Label!!!";
-    CK_DATE emptyStartDate = { "2018", "01", "01" };
-    CK_DATE emptyEndDate = { "2118", "01", "01" };
+    CK_DATE emptyStartDate = { {'2','0','1','8'}, {'0','1'}, {'0','1'} };
+    CK_DATE emptyEndDate = { {'2','1','1','8'}, {'0','1'}, {'0','1'} };
     CK_CHAR emptyLabel[32] = "The Key's Label!!!";
     CK_ATTRIBUTE setGetTmpl[] = {
         { CKA_START_DATE,          &emptyStartDate,     sizeof(CK_DATE)       },


### PR DESCRIPTION
GCC 15.1.1 would generate `-Wunterminated-string-initialization` errors on some of byte arrays. This fixes that.

Fixes #73