### PR TITLE
Login improvements

### DIFF
--- a/src/internal.c
+++ b/src/internal.c
@@ -438,6 +438,7 @@ typedef struct WP11_Token {
     int loginState;                    /* Login state of the token            */
     WP11_Object* object;               /* Linked list of token objects        */
     int objCnt;                        /* Count of objects on token           */
+    int tokenFlags;                    /* Flags for token                     */
 } WP11_Token;
 
 struct WP11_Slot {
@@ -657,6 +658,40 @@ static int wp11_Session_New(WP11_Slot* slot, CK_OBJECT_HANDLE handle,
 }
 
 /**
+ * Check if the slot has an empty user PIN.
+ *
+ * @param  slot     [in]   Slot object.
+ * @return  1 if the slot has an empty user PIN.
+ *          0 if the slot does not have an empty user PIN.
+ */
+int WP11_Slot_Has_Empty_Pin(WP11_Slot* slot)
+{
+    if (slot == NULL)
+        return 0;
+
+    if ((slot->token.tokenFlags & WP11_TOKEN_FLAG_USER_PIN_SET) &&
+        (WP11_Slot_CheckUserPin(slot, (char*)"", 0) == 0))
+        return 1;
+
+    return 0;
+}
+
+/**
+ * Check if the slot has an SO PIN set.
+ *
+ * @param  slot     [in]   Slot object.
+ * @return  1 if the slot has an SO PIN set.
+ *          0 if the slot does not have an SO PIN set.
+ */
+int WP11_Slot_SOPin_IsSet(WP11_Slot* slot)
+{
+    if (slot == NULL)
+        return 0;
+
+    return slot->token.tokenFlags & WP11_TOKEN_FLAG_SO_PIN_SET;
+}
+
+/**
  * Add a new session to the token in the slot.
  *
  * @param  slot     [in]   Slot object.
@@ -806,6 +841,7 @@ static int wolfPKCS11_Store_GetMaxSize(int type, int variableSz)
                 FIELD_SIZE(WP11_Token, userFailLoginTimeout) +
                 FIELD_SIZE(WP11_Token, seed) +
                 FIELD_SIZE(WP11_Token, objCnt) +
+                FIELD_SIZE(WP11_Token, tokenFlags) +
                 variableSz /* soPinLen + userPinLen + (objCnt * long) */
             ;
             break;
@@ -826,7 +862,7 @@ static int wolfPKCS11_Store_GetMaxSize(int type, int variableSz)
                 sizeof(word32) + /* issuerLen */
                 sizeof(word32) + /* serialLen */
                 sizeof(word32) + /* subjectLen */
-                variableSz /* keyIdLen + labelLen + issuerLen + serialLen + issuerLen + serialLen + subjectLen */
+                variableSz /* keyIdLen + labelLen + issuerLen + serialLen + subjectLen */
             ;
             break;
         case WOLFPKCS11_STORE_SYMMKEY:
@@ -1008,6 +1044,11 @@ int wolfPKCS11_Store_OpenSz(int type, CK_ULONG id1, CK_ULONG id2, int read,
             XSNPRINTF(name, sizeof(name), "%s/wp11_cert_%016lx_%016lx",
                       str, id1, id2);
             break;
+        case WOLFPKCS11_STORE_TRUST:
+            XSNPRINTF(name, sizeof(name), "%s/wp11_trust_%016lx_%016lx",
+                      str, id1, id2);
+            break;
+
         default:
             ret = -1;
             break;
@@ -3302,11 +3343,10 @@ static int wp11_Object_Load(WP11_Object* object, int tokenId, int objId)
             ret = wp11_Object_Load_Cert(object, tokenId, objId);
         }
 #ifdef WOLFPKCS11_NSS
-        else if(object->objClass == CKO_NSS_TRUST) {
+        else if (object->objClass == CKO_NSS_TRUST) {
             ret = wp11_Object_Load_Trust(object, tokenId, objId);
         }
 #endif
-
         else {
             /* Load separate key data. */
             switch (object->type) {
@@ -3828,6 +3868,10 @@ static int wp11_Token_Load(WP11_Slot* slot, int tokenId, WP11_Token* token)
                 token->objCnt++;
             }
         }
+        if (ret == 0) {
+            /* Read token flags. */
+            ret = wp11_storage_read_int(storage, &token->tokenFlags);
+        }
 
         wp11_storage_close(storage);
 
@@ -3842,6 +3886,18 @@ static int wp11_Token_Load(WP11_Slot* slot, int tokenId, WP11_Token* token)
             /* Set to state of initialized. */
             token->state = WP11_TOKEN_STATE_INITIALIZED;
         }
+
+        /* If there is no pin, there is no login, so decode now */
+        if (WP11_Slot_Has_Empty_Pin(slot)) {
+#ifndef WOLFPKCS11_NO_STORE
+            object = token->object;
+            while (ret == 0 && object != NULL) {
+                ret = wp11_Object_Decode(object);
+                object = object->next;
+            }
+#endif
+        }
+
         if (ret != 0) {
             ret = CKR_DEVICE_ERROR;
         }
@@ -3940,6 +3996,11 @@ static int wp11_Token_Store(WP11_Token* token, int tokenId)
              * (variable objCnt * 8) */
             ret = wp11_storage_write_ulong(storage, object->type);
             object = object->next;
+        }
+
+        if (ret == 0) {
+            /* Write token flags. (4) */
+            ret = wp11_storage_write_int(storage, token->tokenFlags);
         }
 
         wp11_storage_close(storage);
@@ -4093,6 +4154,8 @@ static int wp11_Slot_Init(WP11_Slot* slot, int id)
     XMEMSET(slot, 0, sizeof(*slot));
     slot->id = id;
     slot->nextObjId = 1;
+    slot->token.state = WP11_TOKEN_STATE_UNKNOWN;
+    slot->token.tokenFlags = 0;
 
     ret = WP11_Lock_Init(&slot->lock);
     if (ret == 0) {
@@ -4107,7 +4170,6 @@ static int wp11_Slot_Init(WP11_Slot* slot, int id)
         }
         if (ret == 0) {
             ret = wp11_Token_Init(&slot->token, label);
-            slot->token.state = WP11_TOKEN_STATE_UNKNOWN;
         }
 
         if (ret != 0) {
@@ -4546,8 +4608,14 @@ int WP11_Slot_CheckSOPin(WP11_Slot* slot, char* pin, int pinLen)
 
     WP11_Lock_LockRO(&slot->lock);
     token = &slot->token;
-    if (token->state != WP11_TOKEN_STATE_INITIALIZED || token->soPinLen == 0)
+
+    if (token->state != WP11_TOKEN_STATE_INITIALIZED)
         ret = PIN_NOT_SET_E;
+#ifndef WOLFPKCS11_NSS
+    /* NSS PK11_InitPin tries to login before setting the pin */
+    if (!(token->tokenFlags & WP11_TOKEN_FLAG_SO_PIN_SET))
+        ret = PIN_NOT_SET_E;
+#endif
     if (ret == 0) {
         WP11_Lock_UnlockRO(&slot->lock);
 
@@ -4583,7 +4651,9 @@ int WP11_Slot_CheckUserPin(WP11_Slot* slot, char* pin, int pinLen)
 
     WP11_Lock_LockRO(&slot->lock);
     token = &slot->token;
-    if (token->state != WP11_TOKEN_STATE_INITIALIZED || token->userPinLen == 0)
+    if (token->state != WP11_TOKEN_STATE_INITIALIZED)
+        ret = PIN_NOT_SET_E;
+    if (!(token->tokenFlags & WP11_TOKEN_FLAG_USER_PIN_SET))
         ret = PIN_NOT_SET_E;
 
     if (ret == 0) {
@@ -4826,6 +4896,7 @@ int WP11_Slot_SetSOPin(WP11_Slot* slot, char* pin, int pinLen)
     }
     if (ret == 0) {
         token->soPinLen = sizeof(token->soPin);
+        token->tokenFlags |= WP11_TOKEN_FLAG_SO_PIN_SET;
     #ifndef WOLFPKCS11_NO_STORE
         ret = wp11_Token_Store(token, (int)slot->id);
     #endif
@@ -4879,6 +4950,7 @@ int WP11_Slot_SetUserPin(WP11_Slot* slot, char* pin, int pinLen)
     }
     if (ret == 0) {
         token->userPinLen = sizeof(token->userPin);
+        token->tokenFlags |= WP11_TOKEN_FLAG_USER_PIN_SET;
     #ifndef WOLFPKCS11_NO_STORE
         ret = wp11_Token_Store(token, (int)slot->id);
     #endif
@@ -4999,7 +5071,7 @@ time_t WP11_Slot_TokenFailedExpire(WP11_Slot* slot, int login)
  */
 int WP11_Slot_IsTokenUserPinInitialized(WP11_Slot* slot)
 {
-    return slot->token.userPinLen > 0;
+    return slot->token.tokenFlags & WP11_TOKEN_FLAG_USER_PIN_SET;
 }
 
 /**
@@ -5906,8 +5978,9 @@ static WP11_Object* wp11_Session_FindNext(WP11_Session* session, int onToken,
         if ((ret->opFlag & WP11_FLAG_PRIVATE) == WP11_FLAG_PRIVATE) {
             if (!onToken)
                 WP11_Lock_LockRO(&session->slot->token.lock);
-            if (session->slot->token.loginState == WP11_APP_STATE_RW_PUBLIC ||
-                  session->slot->token.loginState == WP11_APP_STATE_RO_PUBLIC) {
+            if (!WP11_Slot_Has_Empty_Pin(session->slot) &&
+                (session->slot->token.loginState == WP11_APP_STATE_RW_PUBLIC ||
+                 session->slot->token.loginState == WP11_APP_STATE_RO_PUBLIC)) {
                 object = ret;
                 ret = NULL;
             }
@@ -6827,12 +6900,6 @@ static int GetTrustAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type,
             if (data != NULL)
                 ret = GetBool(object->data.trust.stepUpApproved, data, len);
             break;
-        case CKA_ISSUER:
-            ret = GetData(object->issuer, object->issuerLen, data, len);
-            break;
-        case CKA_SERIAL_NUMBER:
-            ret = GetData(object->serial, object->serialLen, data, len);
-            break;
         default:
             ret = NOT_AVAILABLE_E;
             break;
@@ -7196,6 +7263,12 @@ int WP11_Object_GetAttr(WP11_Object* object, CK_ATTRIBUTE_TYPE type, byte* data,
             break;
         case CKA_LABEL:
             ret = GetData(object->label, object->labelLen, data, len);
+            break;
+        case CKA_ISSUER:
+            ret = GetData(object->issuer, object->issuerLen, data, len);
+            break;
+        case CKA_SERIAL_NUMBER:
+            ret = GetData(object->serial, object->serialLen, data, len);
             break;
         case CKA_SUBJECT:
             ret = GetData(object->subject, object->subjectLen, data, len);

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -40,6 +40,7 @@
 
 #include "unit.h"
 #include "testdata.h"
+#include <wolfpkcs11/internal.h>
 
 
 #define TEST_FLAG_INIT                 0x01
@@ -406,20 +407,18 @@ static CK_RV test_no_token_init(void* args)
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
     CK_RV ret;
     CK_TOKEN_INFO tokenInfo;
-#ifdef WOLFPKCS11_NSS
-    CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN;
-#else
-    CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_LOGIN_REQUIRED;
-#endif
+    CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_TOKEN_INITIALIZED;
     int flags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
 
     session = CK_INVALID_HANDLE;
     ret = funcList->C_OpenSession(slot, flags, NULL, NULL, &session);
     CHECK_CKR(ret, "Open Session");
     if (ret == CKR_OK) {
+#ifndef WOLFPKCS11_NSS
         ret = funcList->C_Login(session, CKU_SO, soPin, soPinLen);
         CHECK_CKR_FAIL(ret, CKR_USER_PIN_NOT_INITIALIZED,
                                                          "Login SO no PIN set");
+#endif
         if (ret == CKR_OK) {
             ret = funcList->C_Login(session, CKU_USER, userPin, userPinLen);
             CHECK_CKR_FAIL(ret, CKR_USER_PIN_NOT_INITIALIZED,
@@ -594,12 +593,7 @@ static CK_RV test_token(void* args)
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
     CK_RV ret;
     CK_TOKEN_INFO tokenInfo;
-#ifdef WOLFPKCS11_NSS
     CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_TOKEN_INITIALIZED;
-#else
-    CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_LOGIN_REQUIRED |
-                        CKF_TOKEN_INITIALIZED;
-#endif
     unsigned char label[32];
     int flags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
 
@@ -674,6 +668,8 @@ static CK_RV test_token(void* args)
     return ret;
 }
 
+#ifndef WOLFPKCS11_NSS
+/* Fails on NSS due to single-session mode */
 static CK_RV test_open_close_session(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
@@ -737,6 +733,7 @@ static CK_RV test_open_close_session(void* args)
 
     return ret;
 }
+#endif
 
 static CK_RV test_pin(void* args)
 {
@@ -763,11 +760,13 @@ static CK_RV test_pin(void* args)
             if (ret == CKR_OK) {
                 ret = funcList->C_InitPIN(session, NULL, userPinLen);
                 CHECK_CKR_FAIL(ret, CKR_ARGUMENTS_BAD, "Init PIN no pin");
+#if WP11_MIN_PIN_LEN > 3
                 if (ret == CKR_OK) {
                     ret = funcList->C_InitPIN(session, userPin, 3);
                     CHECK_CKR_FAIL(ret, CKR_PIN_INCORRECT,
                                                       "Init PIN too short PIN");
                 }
+#endif
                 if (ret == CKR_OK) {
                     ret = funcList->C_InitPIN(session, userPin, 33);
                     CHECK_CKR_FAIL(ret, CKR_PIN_INCORRECT,
@@ -809,12 +808,14 @@ static CK_RV test_pin(void* args)
                 CHECK_CKR_FAIL(ret, CKR_PIN_INCORRECT,
                                                     "Set PIN too long old pin");
             }
+#if WP11_MIN_PIN_LEN > 3
             if (ret == CKR_OK) {
                 ret = funcList->C_SetPIN(session, userPin, userPinLen,userPin,
                                                                              3);
                 CHECK_CKR_FAIL(ret, CKR_PIN_INCORRECT,
                                                    "Set PIN too short new pin");
             }
+#endif
             if (ret == CKR_OK) {
                 ret = funcList->C_SetPIN(session, userPin, userPinLen, userPin,
                                                                             33);
@@ -896,16 +897,9 @@ static CK_RV test_login_logout(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
     CK_RV ret = 0;
-    int roFlags = CKF_SERIAL_SESSION;
-    CK_OBJECT_HANDLE roSession;
     CK_TOKEN_INFO tokenInfo;
-#ifdef WOLFPKCS11_NSS
-    CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN |
-                        CKF_TOKEN_INITIALIZED | CKF_USER_PIN_INITIALIZED;
-#else
     CK_FLAGS expFlags = CKF_RNG | CKF_CLOCK_ON_TOKEN | CKF_LOGIN_REQUIRED |
                         CKF_TOKEN_INITIALIZED | CKF_USER_PIN_INITIALIZED;
-#endif
 
     funcList->C_Logout(session);
 
@@ -963,7 +957,10 @@ static CK_RV test_login_logout(void* args)
                              "Get Token Info - token initialized flag not set");
     }
 
+#if ((WP11_SESSION_CNT_MAX != 1) || (WP11_SESSION_CNT_MIN != 1))
     if (ret == CKR_OK) {
+        CK_OBJECT_HANDLE roSession;
+        int roFlags = CKF_SERIAL_SESSION;
         ret = funcList->C_OpenSession(slot, roFlags, NULL, NULL, &roSession);
         CHECK_CKR(ret, "Login/out - Open Session RO");
         if (ret == CKR_OK) {
@@ -973,6 +970,7 @@ static CK_RV test_login_logout(void* args)
             funcList->C_CloseSession(roSession);
         }
     }
+#endif
 
     return ret;
 }
@@ -1406,7 +1404,9 @@ static CK_RV test_object(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
     CK_RV ret = CKR_OK;
+#ifndef WOLFPKCS11_NSS
     CK_SESSION_HANDLE sessionRO;
+#endif
     static byte keyData[] = { 0x00 };
     CK_ATTRIBUTE tmpl[] = {
         { CKA_CLASS,             &secretKeyClass,   sizeof(secretKeyClass)    },
@@ -1617,14 +1617,14 @@ static CK_RV test_object(void* args)
         ret = funcList->C_DestroyObject(session, obj);
         CHECK_CKR(ret, "Destroy Object");
     }
-
+#ifndef WOLFPKCS11_NSS
     if (ret == CKR_OK) {
         sessionRO = CK_INVALID_HANDLE;
         ret = funcList->C_OpenSession(slot, CKF_SERIAL_SESSION, NULL, NULL,
                                                                     &sessionRO);
         CHECK_CKR(ret, "Open Session - read-only");
     }
-#ifndef WOLFPKCS11_NSS
+
     if (ret == CKR_OK) {
         ret = funcList->C_CreateObject(sessionRO, tmpl, tmplCnt, &obj);
         CHECK_CKR_FAIL(ret, CKR_SESSION_READ_ONLY,
@@ -1641,10 +1641,11 @@ static CK_RV test_object(void* args)
         CHECK_CKR_FAIL(ret, CKR_SESSION_READ_ONLY,
                                          "Destroy object in read-only session");
     }
-#endif
+
     if (ret == CKR_OK && sessionRO != CK_INVALID_HANDLE) {
         funcList->C_CloseSession(sessionRO);
     }
+#endif
     if (ret == CKR_OK) {
         ret = funcList->C_DestroyObject(session, objOnToken);
         CHECK_CKR(ret, "Destroy Object");
@@ -1653,7 +1654,8 @@ static CK_RV test_object(void* args)
     return ret;
 }
 
-#ifdef WOLFPKCS11_NSS
+#if ((defined(WOLFPKCS11_NSS)) && ((WP11_SESSION_CNT_MAX != 1) || \
+    (WP11_SESSION_CNT_MIN != 1)))
 static CK_RV test_cross_session_object(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
@@ -5270,11 +5272,14 @@ static CK_RV test_rsa_fixed_keys_store_token(void* args)
     if (ret == CKR_OK)
         ret = get_rsa_pub_key(session, pubId, pubIdLen, &pub);
 
+#if ((defined(WOLFPKCS11_NSS)) && ((WP11_SESSION_CNT_MAX != 1) || \
+    (WP11_SESSION_CNT_MIN != 1)))
     if (ret == CKR_OK) {
         ret = funcList->C_OpenSession(slot, CKF_SERIAL_SESSION, NULL, NULL,
                                                                     &sessionRO);
         CHECK_CKR(ret, "Open Session read only");
     }
+#endif
     if (ret == CKR_OK)
         ret = find_rsa_priv_key(session, &priv, privId, privIdLen);
     if (ret == CKR_OK)
@@ -13018,7 +13023,9 @@ static TEST_FUNC testFunc[] = {
     PKCS11TEST_FUNC_TOKEN_DECL(test_get_info),
     PKCS11TEST_FUNC_TOKEN_DECL(test_slot),
     PKCS11TEST_FUNC_TOKEN_DECL(test_token),
+#ifndef WOLFPKCS11_NSS
     PKCS11TEST_FUNC_TOKEN_DECL(test_open_close_session),
+#endif
     PKCS11TEST_FUNC_SESS_DECL(test_login_logout),
     PKCS11TEST_FUNC_SESS_DECL(test_pin),
     PKCS11TEST_FUNC_SESS_DECL(test_session),
@@ -13027,7 +13034,8 @@ static TEST_FUNC testFunc[] = {
 #endif
     PKCS11TEST_FUNC_SESS_DECL(test_op_state_fail),
     PKCS11TEST_FUNC_SESS_DECL(test_object),
-#ifdef WOLFPKCS11_NSS
+#if ((defined(WOLFPKCS11_NSS)) && ((WP11_SESSION_CNT_MAX != 1) || \
+    (WP11_SESSION_CNT_MIN != 1)))
     PKCS11TEST_FUNC_SESS_DECL(test_cross_session_object),
 #endif
     PKCS11TEST_FUNC_SESS_DECL(test_attribute),

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -73,14 +73,18 @@ extern "C" {
 /* Maximum number of sessions allocated per slot/token. */
 #ifndef WP11_SESSION_CNT_MAX
 #ifdef WOLFPKCS11_NSS
-#define WP11_SESSION_CNT_MAX           7000
+#define WP11_SESSION_CNT_MAX           1
 #else
 #define WP11_SESSION_CNT_MAX           70
 #endif
 #endif
 /* Minimum number of sessions allocated per slot/token. */
 #ifndef WP11_SESSION_CNT_MIN
+#ifdef WOLFPKCS11_NSS
+#define WP11_SESSION_CNT_MIN           1
+#else
 #define WP11_SESSION_CNT_MIN           2
+#endif
 #endif
 
 /* Session was opened read-only or read/write. */
@@ -144,6 +148,10 @@ extern "C" {
 #define WP11_FLAG_UNWRAP               0x00008000
 #define WP11_FLAG_WRAP                 0x00010000
 #define WP11_FLAG_DERIVE               0x00020000
+
+/* Flags for token. */
+#define WP11_TOKEN_FLAG_USER_PIN_SET   0x00000001
+#define WP11_TOKEN_FLAG_SO_PIN_SET     0x00000002
 
 /* Operation session has initialized for. */
 #define WP11_INIT_AES_CBC_ENC          0x0001
@@ -213,7 +221,11 @@ extern "C" {
 
 /* PIN length constraints. */
 #ifndef WP11_MIN_PIN_LEN
+#ifdef WOLFPKCS11_NSS
+#define WP11_MIN_PIN_LEN               0
+#else
 #define WP11_MIN_PIN_LEN               4
+#endif
 #endif
 #ifndef WP11_MAX_PIN_LEN
 #define WP11_MAX_PIN_LEN               32
@@ -271,6 +283,8 @@ void WP11_Slot_CloseSessions(WP11_Slot* slot);
 int WP11_Slot_HasSession(WP11_Slot* slot);
 int WP11_Slot_CheckSOPin(WP11_Slot* slot, char* pin, int pinLen);
 int WP11_Slot_CheckUserPin(WP11_Slot* slot, char* pin, int pinLen);
+int WP11_Slot_Has_Empty_Pin(WP11_Slot* slot);
+int WP11_Slot_SOPin_IsSet(WP11_Slot* slot);
 int WP11_Slot_SOLogin(WP11_Slot* slot, char* pin, int pinLen);
 int WP11_Slot_UserLogin(WP11_Slot* slot, char* pin, int pinLen);
 void WP11_Slot_Logout(WP11_Slot* slot);


### PR DESCRIPTION
This has the following changes:

* Adds flags handling for token
* Adds token flags for marking whether the user or SO pin are set
* Add empty pin check
* Load token objects at open instead of login for no pin (because login is not required)
* Allow PINs of zero length
* Remove NSS specific CKF_LOGIN_REQUIRED hack
* Remove NSS specific CKF_USER_PIN_INITIALIZED hack
* Remove CKF_LOGIN_REQUIRED if pin is set and empty
* Don't clear the token state just after it is first initialized (CKF_TOKEN_INITIALIZED only got set after reloading token files)
* User and SO pins now have correct setter checks
* Fix some issues with CKO_NSS_TRUST storage
* Make C_FindObject functions work in public mode
* Fix attributes CKA_ISSUER & CKA_SERIAL_NUMBER

The token flags are so that an empty pin can be used. The session count switches to 1 for NSS to work around a bug at login time. NSS would try to do an SO login whilst having another RO session open. Which is not allowed. When max and min session counts are equal to 1, NSS only opens a single session and forces that into RW mode.