### PR TITLE
Fix new master CI tests for NSS

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -29,6 +29,19 @@ on:
 jobs:
   clang-tidy:
     runs-on: ubuntu-latest
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: "Standard Build"
+            configure_flags: ""
+          - name: "NSS Build" 
+            configure_flags: "--enable-nss"
+          - name: "TPM Build"
+            configure_flags: "--enable-tpm"
+          - name: "NSS+TPM Build"
+            configure_flags: "--enable-nss --enable-tpm"
 
     steps:
     # Checkout wolfPKCS11
@@ -46,7 +59,9 @@ jobs:
           clang \
           clang-tidy \
           pkg-config \
-          git
+          git \
+          libnss3-dev \
+          libnspr4-dev
 
     # Build and install wolfSSL
     - name: Build and install wolfSSL
@@ -61,20 +76,47 @@ jobs:
         sudo ldconfig
         cd ..
 
+    # Setup IBM Software TPM (only if TPM enabled)
+    - name: Setup IBM Software TPM
+      if: contains(matrix.config.configure_flags, '--enable-tpm')
+      run: |
+        git clone https://github.com/kgoldman/ibmswtpm2.git
+        cd ibmswtpm2/src
+        make
+        ./tpm_server &
+        cd ../..
+
+    # Build and install wolfTPM (only if TPM enabled)
+    - name: Build and install wolfTPM
+      if: contains(matrix.config.configure_flags, '--enable-tpm')
+      run: |
+        git clone https://github.com/wolfSSL/wolftpm.git
+        cd wolftpm
+        ./autogen.sh
+        ./configure --enable-swtpm
+        make -j$(nproc)
+        sudo make install
+        sudo ldconfig
+        cd ..
+
     # Install bear to generate compilation database
     - name: Install bear
       run: |
         sudo apt-get install -y bear
 
     # Configure and build wolfPKCS11 to generate compilation database
-    - name: Configure and build wolfPKCS11
+    - name: Configure and build wolfPKCS11 (${{ matrix.config.name }})
       run: |
         ./autogen.sh
-        CC=clang CXX=clang++ ./configure --enable-all --enable-debug
+        if [ -n "${{ matrix.config.configure_flags }}" ]; then
+          CC=clang CXX=clang++ ./configure --enable-all --enable-debug ${{ matrix.config.configure_flags }}
+        else
+          CC=clang CXX=clang++ ./configure --enable-all --enable-debug
+        fi
         bear -- make -j$(nproc)
 
     # Run clang-tidy analysis
-    - name: Run clang-tidy
+    - name: Run clang-tidy (${{ matrix.config.name }})
       run: |
         # Find source files to analyze (prioritize main source files)
         echo "Finding source files to analyze..."
@@ -129,7 +171,7 @@ jobs:
         echo "Notes: $NOTES"
 
         # Create a summary for the build
-        echo "Configuration: Standard Build" >> clang-tidy-summary.txt
+        echo "Configuration: ${{ matrix.config.name }}" >> clang-tidy-summary.txt
         echo "Files analyzed: $FILES_ANALYZED" >> clang-tidy-summary.txt
         echo "Warnings: $WARNINGS" >> clang-tidy-summary.txt
         echo "Errors: $ERRORS" >> clang-tidy-summary.txt
@@ -156,7 +198,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: test-logs
+        name: test-logs-${{ matrix.config.name }}
         path: |
           clang-tidy-summary.txt
           clang-tidy-report.txt

--- a/.github/workflows/sanitizer-tests.yml
+++ b/.github/workflows/sanitizer-tests.yml
@@ -11,17 +11,35 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         # msan disabled due to too many failures
         # tsan disabled due to weird failures
         sanitizer: [asan, ubsan]
-        tpm: [false, true]
+        config:
+          - name: "Standard Build"
+            configure_flags: ""
+          - name: "NSS Build" 
+            configure_flags: "--enable-nss"
+          - name: "TPM Build"
+            configure_flags: "--enable-tpm"
+          - name: "NSS+TPM Build"
+            configure_flags: "--enable-nss --enable-tpm"
 
     steps:
 #pull wolfPKCS11
     - uses: actions/checkout@v4
       with:
         submodules: true
+
+#install dependencies
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          build-essential \
+          libnss3-dev \
+          libnspr4-dev
 
 #setup wolfssl
     - uses: actions/checkout@v4
@@ -54,7 +72,7 @@ jobs:
             export LDFLAGS="-fsanitize=undefined"
             ;;
         esac
-        ./configure --enable-cryptocb --enable-aescfb --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt \
+        ./configure --enable-cryptocb --enable-aescfb --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt --enable-debug \
             C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT"
     - name: wolfssl make
       working-directory: ./wolfssl
@@ -68,12 +86,12 @@ jobs:
 
 #setup ibmswtpm2 (only if TPM enabled)
     - uses: actions/checkout@v4
-      if: matrix.tpm
+      if: contains(matrix.config.configure_flags, '--enable-tpm')
       with:
         repository: kgoldman/ibmswtpm2
         path: ibmswtpm2
     - name: ibmswtpm2 make
-      if: matrix.tpm
+      if: contains(matrix.config.configure_flags, '--enable-tpm')
       working-directory: ./ibmswtpm2/src
       run: |
           make
@@ -81,16 +99,16 @@ jobs:
 
 #setup wolftpm (only if TPM enabled)
     - uses: actions/checkout@v4
-      if: matrix.tpm
+      if: contains(matrix.config.configure_flags, '--enable-tpm')
       with:
         repository: wolfssl/wolftpm
         path: wolftpm
     - name: wolftpm autogen
-      if: matrix.tpm
+      if: contains(matrix.config.configure_flags, '--enable-tpm')
       working-directory: ./wolftpm
       run: ./autogen.sh
     - name: wolftpm configure with ${{ matrix.sanitizer }}
-      if: matrix.tpm
+      if: contains(matrix.config.configure_flags, '--enable-tpm')
       working-directory: ./wolftpm
       run: |
         export CC=clang
@@ -113,14 +131,14 @@ jobs:
             export LDFLAGS="-fsanitize=undefined"
             ;;
         esac
-        ./configure --enable-swtpm
+        ./configure --enable-swtpm --enable-debug
     - name: wolftpm make
-      if: matrix.tpm
+      if: contains(matrix.config.configure_flags, '--enable-tpm')
       working-directory: ./wolftpm
       run: |
         make
     - name: wolftpm make install
-      if: matrix.tpm
+      if: contains(matrix.config.configure_flags, '--enable-tpm')
       working-directory: ./wolftpm
       run: |
           sudo make install
@@ -129,7 +147,7 @@ jobs:
 #setup wolfPKCS11
     - name: wolfpkcs11 autogen
       run: ./autogen.sh
-    - name: wolfpkcs11 configure with ${{ matrix.sanitizer }}
+    - name: wolfpkcs11 configure with ${{ matrix.sanitizer }} (${{ matrix.config.name }})
       run: |
         export CC=clang
         export CXX=clang++
@@ -151,21 +169,8 @@ jobs:
             export LDFLAGS="-fsanitize=undefined"
             ;;
         esac
-        if [ "${{ matrix.tpm }}" = "true" ]; then
-          case "${{ matrix.sanitizer }}" in
-            "asan")
-              ./configure --enable-singlethreaded --enable-wolftpm --disable-dh C_EXTRA_FLAGS="-DWOLFPKCS11_TPM_STORE"
-              ;;
-            "msan")
-              ./configure --enable-singlethreaded --enable-wolftpm --disable-dh C_EXTRA_FLAGS="-DWOLFPKCS11_TPM_STORE"
-              ;;
-            "tsan")
-              ./configure --enable-singlethreaded --enable-wolftpm --disable-dh C_EXTRA_FLAGS="-DWOLFPKCS11_TPM_STORE"
-              ;;
-            "ubsan")
-              ./configure --enable-singlethreaded --enable-wolftpm --disable-dh C_EXTRA_FLAGS="-DWOLFPKCS11_TPM_STORE"
-              ;;
-          esac
+        if [ -n "${{ matrix.config.configure_flags }}" ]; then
+          ./configure ${{ matrix.config.configure_flags }}
         else
           ./configure
         fi
@@ -177,7 +182,7 @@ jobs:
         if [ "${{ matrix.sanitizer }}" = "tsan" ]; then
           export TSAN_OPTIONS="suppressions=$PWD/tsan_suppressions.txt"
         fi
-        if [ "${{ matrix.tpm }}" = "true" ]; then
+        if [[ "${{ matrix.config.configure_flags }}" == *"--enable-tpm"* ]]; then
           ./tests/pkcs11str && ./tests/pkcs11test
         else
           make check
@@ -188,7 +193,7 @@ jobs:
       if: failure() || cancelled()
       uses: actions/upload-artifact@v4
       with:
-        name: wolfpkcs11-${{ matrix.sanitizer }}-${{ matrix.tpm && 'tpm' || 'notpm' }}-test-logs
+        name: wolfpkcs11-${{ matrix.sanitizer }}-${{ matrix.config.name }}-test-logs
         path: |
           test-suite.log
         retention-days: 5

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -6480,6 +6480,10 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
                                     ulAttributeCount, phKey);
                 }
             }
+            else {
+                WP11_Object_Free(obj);
+                rv = ret;
+            }
         }
     }
 

--- a/src/slot.c
+++ b/src/slot.c
@@ -742,48 +742,36 @@ CK_RV C_GetMechanismInfo(CK_SLOT_ID slotID, CK_MECHANISM_TYPE type,
     #endif
     #ifndef NO_SHA256
         case CKM_SHA256_RSA_PKCS:
-            XMEMCPY(pInfo, &shaRsaPkcsMechInfo, sizeof(CK_MECHANISM_INFO));
-            break;
     #endif
     #ifdef WOLFSSL_SHA224
         case CKM_SHA224_RSA_PKCS:
-            XMEMCPY(pInfo, &shaRsaPkcsMechInfo, sizeof(CK_MECHANISM_INFO));
-            break;
     #endif
     #ifdef WOLFSSL_SHA384
         case CKM_SHA384_RSA_PKCS:
-            XMEMCPY(pInfo, &shaRsaPkcsMechInfo, sizeof(CK_MECHANISM_INFO));
-            break;
     #endif
     #ifdef WOLFSSL_SHA512
         case CKM_SHA512_RSA_PKCS:
+    #endif
             XMEMCPY(pInfo, &shaRsaPkcsMechInfo, sizeof(CK_MECHANISM_INFO));
             break;
-    #endif
     #ifdef WC_RSA_PSS
         case CKM_RSA_PKCS_PSS:
             XMEMCPY(pInfo, &rsaPssMechInfo, sizeof(CK_MECHANISM_INFO));
             break;
         #ifndef NO_SHA256
         case CKM_SHA256_RSA_PKCS_PSS:
-            XMEMCPY(pInfo, &shaRsaPkcsMechInfo, sizeof(CK_MECHANISM_INFO));
-            break;
         #endif
         #ifdef WOLFSSL_SHA224
         case CKM_SHA224_RSA_PKCS_PSS:
-            XMEMCPY(pInfo, &shaRsaPkcsMechInfo, sizeof(CK_MECHANISM_INFO));
-            break;
         #endif
         #ifdef WOLFSSL_SHA384
         case CKM_SHA384_RSA_PKCS_PSS:
-            XMEMCPY(pInfo, &shaRsaPkcsMechInfo, sizeof(CK_MECHANISM_INFO));
-            break;
         #endif
         #ifdef WOLFSSL_SHA512
         case CKM_SHA512_RSA_PKCS_PSS:
+        #endif
             XMEMCPY(pInfo, &shaRsaPkcsMechInfo, sizeof(CK_MECHANISM_INFO));
             break;
-        #endif
     #endif
 #endif
 #ifdef HAVE_ECC

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -1368,8 +1368,8 @@ static CK_RV test_op_state_fail(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
     CK_RV ret;
-    byte data;
-    CK_ULONG len;
+    byte data = 0x00;
+    CK_ULONG len = 0;
 
     ret = funcList->C_GetOperationState(CK_INVALID_HANDLE, NULL, &len);
     CHECK_CKR_FAIL(ret, CKR_SESSION_HANDLE_INVALID,
@@ -6270,7 +6270,7 @@ static CK_RV ecdsa_test(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE privKey,
     return ret;
 }
 
-/* Tests for error occuring when private and public curves mismatch. */
+/* Tests for error occurring when private and public curves mismatch. */
 /* Crashes with TPM test right now. */
 #ifndef WOLFPKCS11_TPM
 static CK_RV test_ecc_curve(void *args)
@@ -6397,6 +6397,12 @@ static CK_RV test_ecc_curve(void *args)
             &hSharedSecret);
         CHECK_CKR(ret, "C_DeriveKey (ECDH1)");
     }
+    funcList->C_DestroyObject(session, hSharedSecret);
+    funcList->C_DestroyObject(session, hAlicePrivKey);
+    funcList->C_DestroyObject(session, hAlicePubKey);
+    funcList->C_DestroyObject(session, hBobPrivKey);
+    funcList->C_DestroyObject(session, hBobPubKey);
+    XFREE(bobEcPointAttr.pValue, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     return ret;
 }
@@ -7226,7 +7232,7 @@ static CK_RV aes_cbc_encrypt_data_test(CK_SESSION_HANDLE session,
         if (outSz != sizeof(aes_128_cbc_encrypt_exp) ||
                              memcmp(out, aes_128_cbc_encrypt_exp, outSz) != 0) {
             ret = -1;
-            CHECK_CKR(ret, "Secret compare with exepcted");
+            CHECK_CKR(ret, "Secret compare with expected");
         }
     }
     if (ret == CKR_OK) {


### PR DESCRIPTION
* Update tests so that they run in a matrix using NSS and TPM
* Fix leak and error handling when `SymmKeyLen` `ret != 0`
* Fix `CKA_SENSITIVE` handling for metadata (caused `SummKeyLen` issue)
* Fixed cases of duplicate successive bodys for if / switch statements
* Fixed some spelling errors
* Fixed potential library leak
* Fixed leak of issuer, serial and subject attributes
* Fixed type issues with CLang
* Fixed stack overflow in `test_op_state_fail`
* Fixed cleanup in `test_ecc_curve`