### PR TITLE
Align GH Actions retention policy

### DIFF
--- a/.github/workflows/nss-cmsutil-test.yml
+++ b/.github/workflows/nss-cmsutil-test.yml
@@ -367,4 +367,4 @@ jobs:
       with:
         name: nss-cmsutil-test-artifacts
         path: /tmp/nss-cmsutil-test-artifacts.tar.gz
-        retention-days: 30
+        retention-days: 5

--- a/.github/workflows/nss-pdfsig-test.yml
+++ b/.github/workflows/nss-pdfsig-test.yml
@@ -312,4 +312,4 @@ jobs:
           /tmp/test.pdf
           /tmp/signed.pdf
           /tmp/*.log
-        retention-days: 7
+        retention-days: 5

--- a/.github/workflows/nss-ssltap-test.yml
+++ b/.github/workflows/nss-ssltap-test.yml
@@ -340,7 +340,7 @@ jobs:
         echo "========================================"
 
     - name: Upload test logs
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v4
       with:
         name: nss-ssltap-test-logs


### PR DESCRIPTION
Retain only on failure, and for 5 days.