### PR TITLE
Fix failing x86 TPM test

### DIFF
--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -6839,6 +6839,11 @@ static CK_RV test_ecc_gen_keys(void* args)
     if (ret == CKR_OK)
        ret = ecdsa_test(session, priv, pub);
 
+    if (priv != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, priv);
+    if (pub != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, pub);
+
     return ret;
 }
 
@@ -6861,6 +6866,11 @@ static CK_RV test_ecc_gen_keys_id(void* args)
     }
     if (ret == CKR_OK)
         ret = ecdsa_test(session, priv, pub);
+
+    if (priv != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, priv);
+    if (pub != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, pub);
 
     return ret;
 }
@@ -6896,6 +6906,11 @@ static CK_RV test_ecc_token_keys_ecdsa(void* args)
         ret = find_ecc_pub_key(session, &pub, pubId, pubIdLen);
     if (ret == CKR_OK)
         ret = ecdsa_test(session, priv, pub);
+
+    if (priv != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, priv);
+    if (pub != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, pub);
 
     return ret;
 }


### PR DESCRIPTION
Cleanup left over ECC keys which are believed to cause occasional x86 TPM failures.