### PR TITLE
Improve Debian support

### DIFF
--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -1,0 +1,69 @@
+wolfPKCS11 for Debian
+======================
+
+This package provides the wolfPKCS11 cryptographic library with PKCS#11 interface.
+
+Building the Package
+--------------------
+
+To build debian packages from source, you can use the standard debian tools:
+
+1. Install build dependencies:
+   ```
+   sudo apt-get install build-essential debhelper-compat libwolfssl-dev
+   ```
+
+2. Build the package using dpkg-buildpackage:
+   ```
+   dpkg-buildpackage -us -uc
+   ```
+
+   Or using debuild:
+   ```
+   debuild -us -uc
+   ```
+
+3. The resulting .deb files will be created in the parent directory.
+
+Alternative Build Method
+------------------------
+
+This package also supports the legacy build method using the existing Makefile
+targets:
+
+```
+make deb
+```
+
+This method uses custom debian packaging logic built into the Makefile and may
+be useful for specialized builds or development purposes.
+
+Package Contents
+----------------
+
+- libwolfpkcs11: The main shared library package
+- libwolfpkcs11-dev: Development headers and static libraries
+
+Configuration
+-------------
+
+The library supports various configuration options. For debian packaging,
+the following configure options are used by default:
+
+- --enable-debug: Enable debug support
+- --enable-aesecb: Enable AES ECB support
+- --enable-nss: Enable NSS compatibility
+
+These can be customized by modifying the debian/rules file if needed.
+
+Dependencies
+------------
+
+The package depends on libwolfssl which should be available in your debian
+repository. If building from source, ensure libwolfssl-dev is installed.
+
+For more information about wolfPKCS11, visit:
+https://www.wolfssl.com/
+https://github.com/wolfSSL/wolfPKCS11
+
+ -- wolfSSL <support@wolfssl.com>

--- a/debian/include.am
+++ b/debian/include.am
@@ -7,6 +7,12 @@ EXTRA_DIST+= debian/control
 EXTRA_DIST+= debian/control.in
 EXTRA_DIST+= debian/copyright
 EXTRA_DIST+= debian/include.am
+EXTRA_DIST+= debian/rules
+EXTRA_DIST+= debian/libwolfpkcs11.install
+EXTRA_DIST+= debian/libwolfpkcs11-dev.install
+EXTRA_DIST+= debian/libwolfpkcs11.lintian-overrides
+EXTRA_DIST+= debian/libwolfpkcs11-dev.lintian-overrides
+EXTRA_DIST+= debian/README.Debian
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 

--- a/debian/libwolfpkcs11-dev.install
+++ b/debian/libwolfpkcs11-dev.install
@@ -1,0 +1,3 @@
+usr/include/
+usr/lib/*/libwolfpkcs11.so
+usr/bin/wolfpkcs11-config

--- a/debian/libwolfpkcs11-dev.lintian-overrides
+++ b/debian/libwolfpkcs11-dev.lintian-overrides
@@ -1,0 +1,3 @@
+# Override for missing manual page - wolfpkcs11-config is a simple script
+# and doesn't warrant a full manual page
+libwolfpkcs11-dev: binary-without-manpage usr/bin/wolfpkcs11-config

--- a/debian/libwolfpkcs11.install
+++ b/debian/libwolfpkcs11.install
@@ -1,0 +1,1 @@
+usr/lib/*/libwolfpkcs11.so.*

--- a/debian/libwolfpkcs11.lintian-overrides
+++ b/debian/libwolfpkcs11.lintian-overrides
@@ -1,0 +1,7 @@
+# Override for package name not matching soname - this is intentional
+# as we use a custom naming scheme for our packages
+libwolfpkcs11: package-name-doesnt-match-sonames
+
+# Override for missing manual page - wolfpkcs11-config is a simple script
+# and doesn't warrant a full manual page
+libwolfpkcs11: binary-without-manpage usr/bin/wolfpkcs11-config

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,56 @@
+#!/usr/bin/make -f
+# -*- makefile -*-
+
+# Uncomment this to turn on verbose mode.
+#export DH_VERBOSE=1
+
+# This has to be exported to make some magic below work.
+export DH_OPTIONS
+
+# Enable hardening build flags
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+
+# Get build flags
+DPKG_EXPORT_BUILDFLAGS = 1
+include /usr/share/dpkg/buildflags.mk
+
+# Configure options for the build
+CONFIGURE_OPTS = --enable-debug --enable-aesecb --enable-nss
+
+%:
+	dh $@ --with autoreconf
+
+override_dh_auto_configure:
+	dh_auto_configure -- $(CONFIGURE_OPTS)
+
+override_dh_auto_build:
+	dh_auto_build
+
+override_dh_auto_test:
+	# Run tests if they exist
+	-dh_auto_test
+
+override_dh_auto_install:
+	dh_auto_install --destdir=debian/tmp
+	# Remove .la files as per Debian policy
+	find debian/tmp -name '*.la' -delete
+
+override_dh_install:
+	dh_install
+
+override_dh_makeshlibs:
+	dh_makeshlibs -plibwolfpkcs11
+
+override_dh_shlibdeps:
+	dh_shlibdeps -plibwolfpkcs11
+
+override_dh_strip:
+	dh_strip -plibwolfpkcs11 --dbgsym-migration='libwolfpkcs11-dbg (<< 1.3.0~)'
+	dh_strip -plibwolfpkcs11-dev
+
+override_dh_clean:
+	dh_clean
+	# Clean up any generated files
+	-$(MAKE) distclean
+	rm -f config.log config.status
+	rm -rf autom4te.cache


### PR DESCRIPTION
Add `rules` and other related files.

Note that `token_path_test` will fail during package building until #110 is merged.