### PR TITLE
Improve TPM use of handles

### DIFF
--- a/tests/include.am
+++ b/tests/include.am
@@ -45,7 +45,6 @@ tests_rsa_session_persistence_test_LDADD += src/libwolfpkcs11.la
 tests_debug_test_LDADD += src/libwolfpkcs11.la
 tests_object_id_uniqueness_test_LDADD += src/libwolfpkcs11.la
 else
-tests_debug_test_LDADD += src/libwolfpkcs11.la
 tests_object_id_uniqueness_test_LDADD += src/libwolfpkcs11.la
 endif
 

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -64,6 +64,13 @@
 static void* dlib;
 #endif
 static CK_FUNCTION_LIST* funcList;
+
+#ifdef DEBUG_WOLFPKCS11
+#ifndef HAVE_PKCS11_STATIC
+void (*wolfPKCS11_Debugging_On_fp)(void) = NULL;
+void (*wolfPKCS11_Debugging_Off_fp)(void) = NULL;
+#endif
+#endif
 static int slot = 0;
 static const char* tokenName = "wolfpkcs11";
 
@@ -13947,6 +13954,16 @@ static CK_RV pkcs11_init(const char* library)
             ret = -1;
         }
     }
+
+#ifdef DEBUG_WOLFPKCS11
+    if (ret == CKR_OK) {
+        wolfPKCS11_Debugging_On_fp = (void (*)(void))dlsym(dlib,
+                                                     "wolfPKCS11_Debugging_On");
+        wolfPKCS11_Debugging_Off_fp = (void (*)(void))dlsym(dlib,
+                                                    "wolfPKCS11_Debugging_Off");
+        /* These functions are optional, so don't fail if they're not found */
+    }
+#endif
 
     if (ret == CKR_OK) {
         ret = ((CK_C_GetFunctionList)func)(&funcList);

--- a/tests/unit.h
+++ b/tests/unit.h
@@ -19,6 +19,25 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
 
+/* Forward declarations for debugging function pointers */
+#ifdef DEBUG_WOLFPKCS11
+#ifndef HAVE_PKCS11_STATIC
+extern void (*wolfPKCS11_Debugging_On_fp)(void);
+extern void (*wolfPKCS11_Debugging_Off_fp)(void);
+#endif
+
+/* Wrapper function to handle both static and dynamic debugging calls */
+static inline void call_wolfPKCS11_Debugging_On(void) {
+#ifndef HAVE_PKCS11_STATIC
+    if (wolfPKCS11_Debugging_On_fp != NULL) {
+        wolfPKCS11_Debugging_On_fp();
+    }
+#else
+    wolfPKCS11_Debugging_On();
+#endif
+}
+#endif
+
 #ifdef DEBUG_WOLFPKCS11
 #define CHECK_COND(cond, ret, msg)                                         \
     do {                                                                   \
@@ -320,6 +339,12 @@ static CK_RV run_tests(TEST_FUNC* testFunc, int testFuncCnt, int onlySet,
     CK_RV ret = CKR_OK;
     int i;
     void* testArgs;
+
+#ifdef DEBUG_WOLFPKCS11
+    if (verbose) {
+        call_wolfPKCS11_Debugging_On();
+    }
+#endif
 
     for (i = 0; i < testFuncCnt; i++) {
         if (testFunc[i].flags != flags)

--- a/wolfpkcs11/pkcs11.h
+++ b/wolfpkcs11/pkcs11.h
@@ -1096,8 +1096,13 @@ struct CK_FUNCTION_LIST {
 };
 
 /* Debug control functions */
+#ifdef DEBUG_WOLFPKCS11
 WP11_API void wolfPKCS11_Debugging_On(void);
 WP11_API void wolfPKCS11_Debugging_Off(void);
+#else
+#define wolfPKCS11_Debugging_On()
+#define wolfPKCS11_Debugging_Off()
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add support for importing external RSA/ECC private keys and encrypting them using TPM. Requires https://github.com/wolfSSL/wolfTPM/pull/428
Enhanced support for TPM handle usage to only load when needed. Allows many concurrent keys to be active.
Added tests -v to also enable `wolfPKCS11_Debugging_On` and fixed issue with function availability.
Improve PKCS11 store error return code logic.