### PR TITLE
Fixes and improvements for TPM NV

### DIFF
--- a/wolfpkcs11/store.h
+++ b/wolfpkcs11/store.h
@@ -51,6 +51,19 @@
 WP11_LOCAL int wolfPKCS11_Store_Open(int type, CK_ULONG id1, CK_ULONG id2, int read,
     void** store);
 
+
+/*
+ * Removes stored data from the specified location.
+ *
+ * @param [in]  type   Type of data to be removed. See WOLFPKCS11_STORE_* above.
+ * @param [in]  id1    Numeric identifier 1.
+ * @param [in]  id2    Numeric identifier 2.
+ * @return  0 on success.
+ * @return  -4 when data not available.
+ * @return  Other value to indicate failure.
+ */
+WP11_LOCAL int wolfPKCS11_Store_Remove(int type, CK_ULONG id1, CK_ULONG id2);
+
 /*
  * Opens access to location to read/write token data.
  *


### PR DESCRIPTION
* Fix to properly remove TPM NV objects on "unstore".
* Fix for `WP11_Object_WrapTpmKey` that was incorrectly setting the `WP11_FLAG_TPM` for public keys. 
* Fix to make sure the loaded RSA/ECC public keys have their devId set to allow crypto callback.
* Improvement to immediately encrypt/wrap any RSA or ECC private keys with TPM and store them in NV that way. 
* Fix to better handle/recover from a TPM NV out of space scenario.
ZD 20306