### PR TITLE
Cleanup unstore logic

### DIFF
--- a/.github/workflows/alpine-architecture-tests.yml
+++ b/.github/workflows/alpine-architecture-tests.yml
@@ -65,7 +65,7 @@ jobs:
         cd wolfssl-${{ matrix.alpine_arch }}
         ./autogen.sh
         ./configure --enable-cryptocb --enable-aescfb --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt --enable-md5 --enable-sha224 --enable-sha3 \
-            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT"
+            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT -DHAVE_AES_ECB -DHAVE_AES_KEYWRAP"
         make
       shell: alpine.sh {0}
 

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -35,7 +35,7 @@ jobs:
       working-directory: ./wolfssl
       run: |
         ./configure --enable-cryptocb --enable-aescfb --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt --enable-md5 \
-            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT"
+            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT -DHAVE_AES_ECB -DHAVE_AES_KEYWRAP"
     - name: wolfssl make install
       working-directory: ./wolfssl
       run: make

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -70,7 +70,7 @@ jobs:
         cd wolfssl
         ./autogen.sh
         ./configure --enable-cryptocb --enable-aescfb --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt --enable-md5 \
-            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT"
+            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT -DHAVE_AES_ECB -DHAVE_AES_KEYWRAP"
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/.github/workflows/debian-package-test.yml
+++ b/.github/workflows/debian-package-test.yml
@@ -34,7 +34,7 @@ jobs:
       working-directory: ./wolfssl
       run: |
         ./configure --enable-cryptocb --enable-aescfb --enable-aesctr  --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt --enable-md5 --enable-cmac \
-            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT -DHAVE_AES_ECB"
+            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT -DHAVE_AES_ECB -DHAVE_AES_KEYWRAP"
     - name: wolfssl make and install
       working-directory: ./wolfssl
       run: |

--- a/.github/workflows/sanitizer-tests.yml
+++ b/.github/workflows/sanitizer-tests.yml
@@ -73,7 +73,7 @@ jobs:
             ;;
         esac
         ./configure --enable-cryptocb --enable-aescfb --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt --enable-md5 --enable-debug \
-            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT"
+            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT -DHAVE_AES_ECB -DHAVE_AES_KEYWRAP"
     - name: wolfssl make
       working-directory: ./wolfssl
       run: |

--- a/.github/workflows/wolfssl-v5.6.6-build-workflow.yml
+++ b/.github/workflows/wolfssl-v5.6.6-build-workflow.yml
@@ -56,7 +56,7 @@ jobs:
       working-directory: ./wolfssl
       run: |
         ./configure --enable-cryptocb --enable-aescfb --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt \
-            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT"
+            C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT -DHAVE_AES_ECB -DHAVE_AES_KEYWRAP"
     - name: wolfssl make install
       if: steps.cache-wolfssl.outputs.cache-hit != 'true'
       working-directory: ./wolfssl

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Build wolfSSL:
 git clone https://github.com/wolfSSL/wolfssl.git
 cd wolfssl
 ./autogen.sh
-./configure --enable-aescfb --enable-cryptocb --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT"
+./configure --enable-aescfb --enable-cryptocb --enable-rsapss --enable-keygen --enable-pwdbased --enable-scrypt C_EXTRA_FLAGS="-DWOLFSSL_PUBLIC_MP -DWC_RSA_DIRECT -DHAVE_AES_ECB -DHAVE_AES_KEYWRAP"
 make
 make check
 sudo make install

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -660,7 +660,9 @@ static CK_RV SetAttributeValue(WP11_Session* session, WP11_Object* obj,
         }
         ret = WP11_Object_SetAttr(obj, attr->type, (byte*)attr->pValue,
                                                               attr->ulValueLen);
-        if (ret == BAD_FUNC_ARG)
+        if (ret == MEMORY_E)
+            return CKR_DEVICE_MEMORY;
+        else if (ret == BAD_FUNC_ARG)
             return CKR_ATTRIBUTE_VALUE_INVALID;
         else if (ret == BUFFER_E)
             return CKR_BUFFER_TOO_SMALL;
@@ -884,7 +886,8 @@ static CK_RV AddRSAPrivateKeyObject(WP11_Session* session,
 err_out:
     if (rv != CKR_OK) {
         if (*phKey != CK_INVALID_HANDLE) {
-            WP11_Session_RemoveObject(session, privKeyObject);
+            /* ignore return value, logged in function */
+            (void)WP11_Session_RemoveObject(session, privKeyObject);
             *phKey = CK_INVALID_HANDLE;
         }
         if (privKeyObject != NULL) {
@@ -1050,7 +1053,8 @@ CK_RV C_CreateObject(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pTemplate,
     }
     rv = AddObject(session, object, pTemplate, ulCount, phObject);
     if (rv != CKR_OK) {
-        WP11_Session_RemoveObject(session, object);
+        /* ignore return value, logged in function */
+        (void)WP11_Session_RemoveObject(session, object);
         WP11_Object_Free(object);
     }
 
@@ -1232,10 +1236,9 @@ CK_RV C_DestroyObject(CK_SESSION_HANDLE hSession,
         return rv;
     }
 
-    WP11_Session_RemoveObject(session, obj);
+    rv = WP11_Session_RemoveObject(session, obj);
     WP11_Object_Free(obj);
 
-    rv = CKR_OK;
     WOLFPKCS11_LEAVE("C_DestroyObject", rv);
     return rv;
 }
@@ -6731,7 +6734,8 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
             }
             if (rv != CKR_OK) {
                 if (*phKey != CK_INVALID_HANDLE) {
-                    WP11_Session_RemoveObject(session, keyObj);
+                    /* ignore return value, logged in function */
+                    (void)WP11_Session_RemoveObject(session, keyObj);
                     *phKey = CK_INVALID_HANDLE;
                 }
                 if (keyObj != NULL) {

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -3792,7 +3792,7 @@ static CK_RV test_generate_key_pair(void* args)
 }
 #endif
 
-#ifdef HAVE_AES_KEYWRAP
+#if defined(HAVE_AES_KEYWRAP) && !defined(WOLFPKCS11_NO_STORE)
 static CK_RV test_aes_wrap_unwrap_key(void* args)
 {
     CK_SESSION_HANDLE session = *(CK_SESSION_HANDLE*)args;
@@ -3881,7 +3881,6 @@ static CK_RV test_aes_wrap_unwrap_pad_key(void* args)
 
     return ret;
 }
-#endif /* HAVE_AES_KEYWRAP */
 
 static CK_RV test_wrap_unwrap_key(void* args)
 {
@@ -4006,6 +4005,7 @@ static CK_RV test_wrap_unwrap_key(void* args)
 
     return ret;
 }
+#endif /* HAVE_AES_KEYWRAP && !WOLFPKCS11_NO_STORE */
 
 #ifndef NO_DH
 static CK_RV test_derive_key(void* args)
@@ -13646,11 +13646,11 @@ static TEST_FUNC testFunc[] = {
 #if !defined(NO_RSA) && defined(WOLFSSL_KEY_GEN)
     PKCS11TEST_FUNC_SESS_DECL(test_generate_key_pair),
 #endif
-#ifdef HAVE_AES_KEYWRAP
+#if defined(HAVE_AES_KEYWRAP) && !defined(WOLFPKCS11_NO_STORE)
     PKCS11TEST_FUNC_SESS_DECL(test_aes_wrap_unwrap_key),
     PKCS11TEST_FUNC_SESS_DECL(test_aes_wrap_unwrap_pad_key),
-#endif
     PKCS11TEST_FUNC_SESS_DECL(test_wrap_unwrap_key),
+#endif /* HAVE_AES_KEYWRAP && !WOLFPKCS11_NO_STORE */
 #ifndef NO_DH
     PKCS11TEST_FUNC_SESS_DECL(test_derive_key),
 #endif

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -358,7 +358,7 @@ WP11_LOCAL int WP11_Session_SetCtsParams(WP11_Session* session, unsigned char* i
                               int enc, WP11_Object* object);
 WP11_LOCAL int WP11_Session_AddObject(WP11_Session* session, int onToken,
                            WP11_Object* object);
-WP11_LOCAL void WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object);
+WP11_LOCAL int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object);
 WP11_LOCAL void WP11_Session_GetObject(WP11_Session* session, WP11_Object** object);
 WP11_LOCAL void WP11_Session_SetObject(WP11_Session* session, WP11_Object* object);
 


### PR DESCRIPTION
Fixes to properly unstore removed objects and to properly re-index them without leaving stray store objects. 
Fixes to prevent malloc(0) with zero size. 
Fix for AES Keywrap and added tests.