### PR TITLE
Fix empty PIN handling for FIPS

### DIFF
--- a/.github/workflows/nss-pk12util-debian-test.yml
+++ b/.github/workflows/nss-pk12util-debian-test.yml
@@ -179,6 +179,11 @@ jobs:
         if [ -f "/tmp/nss-packages/libnss3_"*.deb ]; then
           echo "Using cached NSS packages:"
           ls -la /tmp/nss-packages/
+
+          # Install build dependencies when using cached packages
+          echo "Installing NSS build dependencies for cached packages..."
+          apt-get build-dep -y libnss3
+
           cd /tmp/nss-packages
         else
           echo "Using freshly built NSS packages:"

--- a/src/internal.c
+++ b/src/internal.c
@@ -5757,10 +5757,12 @@ static int HashPIN(char* pin, int pinLen, byte* seed, int seedLen, byte* hash,
                    int hashLen, WP11_Slot* slot)
 {
 #ifdef WOLFPKCS11_PBKDF2
-#if defined(HAVE_FIPS)
+#if defined(HAVE_FIPS) && defined(WOLFPKCS11_NSS)
     if (pinLen == 0) {
         /* For FIPS, use empty pin of HMAC_FIPS_MIN_KEY bytes when pinLen is 0.
          * Otherwise we hit HMAC_MIN_KEYLEN_E.
+         * Certain NSS tools will try to login a blank token with an empty pin
+         * and this needs to succeed, or the tool will fail.
          */
         byte emptyPin[HMAC_FIPS_MIN_KEY];
         XMEMSET(emptyPin, 0, sizeof(emptyPin));

--- a/src/slot.c
+++ b/src/slot.c
@@ -1839,6 +1839,9 @@ CK_RV C_Login(CK_SESSION_HANDLE hSession, CK_USER_TYPE userType,
         case PIN_NOT_SET_E:
             rv = CKR_USER_PIN_NOT_INITIALIZED;
             break;
+        /* No better error matches for pin too short for PBKDF2 HMAC */
+        case BAD_LENGTH_E:
+        case HMAC_MIN_KEYLEN_E:
         case PIN_INVALID_E:
             rv = CKR_PIN_INCORRECT;
             break;


### PR DESCRIPTION
When PBKDF2 is used for PIN handling, if the pin is too small, this produces an error. This breaks our ability to have empty PINs.

Instead, we used a padded empty value.