### PR TITLE
Fix resource leaks and secure buffer erasing

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -2372,7 +2372,7 @@ CK_RV C_Encrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData,
 
             ret = WP11_AesKeyWrap_Encrypt(paddedData, (word32)ulDataLen + padding,
                                           pEncryptedData, &encDataLen, session);
-            XMEMSET(paddedData, 0, ulDataLen + padding);
+            wc_ForceZero(paddedData, ulDataLen + padding);
             XFREE(paddedData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             if (ret != 0)
                 return CKR_FUNCTION_FAILED;
@@ -7301,7 +7301,7 @@ CK_RV C_WrapKey(CK_SESSION_HANDLE hSession,
 err_out:
 
     if (serialBuff != NULL) {
-        XMEMSET(serialBuff, 0, serialSize);
+        wc_ForceZero(serialBuff, serialSize);
         XFREE(serialBuff, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
 
@@ -7532,7 +7532,7 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
 err_out:
 
     if (workBuffer != NULL) {
-        XMEMSET(workBuffer, 0, ulWrappedKeyLen);
+        wc_ForceZero(workBuffer, ulWrappedKeyLen);
         XFREE(workBuffer, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
 
@@ -7968,7 +7968,7 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
 
             /* Freeing here so that we don't attempt to generate a key at the
              * end of the function */
-            XMEMSET(derivedKey, 0, keyLen);
+            wc_ForceZero(derivedKey, keyLen);
             XFREE(derivedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             derivedKey = NULL;
 
@@ -8086,7 +8086,7 @@ CK_RV C_DeriveKey(CK_SESSION_HANDLE hSession,
     }
 
     if (derivedKey != NULL) {
-        XMEMSET(derivedKey, 0, keyLen);
+        wc_ForceZero(derivedKey, keyLen);
         XFREE(derivedKey, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
 #endif

--- a/src/internal.c
+++ b/src/internal.c
@@ -4219,7 +4219,7 @@ static int wp11_Object_Decode_MldsaKey(WP11_Object* object)
                 ret = MldsaKeyTryDecode(object->data.mldsaKey, WC_ML_DSA_87,
                                         der, len, object->objClass);
             }
-            XMEMSET(der, 0, len);
+            wc_ForceZero(der, len);
         }
         if (der != NULL)
             XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -10663,6 +10663,9 @@ static int WP11_Object_WrapTpmKey(WP11_Object* object)
                         (word32)exponent, q, qSz, TPM_ALG_NULL, TPM_ALG_NULL);
                 }
                 (void)p;
+                wc_ForceZero(d, sizeof(d));
+                wc_ForceZero(p, sizeof(p));
+                wc_ForceZero(q, sizeof(q));
             #endif
                 if (ret == 0) {
                     /* set flag indicating this is TPM based key */
@@ -10745,6 +10748,7 @@ static int WP11_Object_WrapTpmKey(WP11_Object* object)
                         &object->slot->tpmSrk, object->tpmKey, curve_id,
                         qx, qxSz, qy, qySz, d, dSz);
                 }
+                wc_ForceZero(d, sizeof(d));
         #endif
                 if (ret == 0) {
                     /* set flag indicating this is TPM based key */

--- a/src/internal.c
+++ b/src/internal.c
@@ -3965,9 +3965,6 @@ static int wp11_Object_Decode_EccKey(WP11_Object* object)
                                     sizeof(object->iv), object->devId);
         }
         if (ret == 0) {
-            ret = wc_ecc_init_ex(key, NULL, object->devId);
-        }
-        if (ret == 0) {
             /* Decode ECC private key. */
             ret = wc_EccPrivateKeyDecode(der, &idx, key, len);
             wc_ForceZero(der, len);
@@ -6424,7 +6421,7 @@ void WP11_Slot_CloseSessions(WP11_Slot* slot)
     WP11_Lock_LockRW(&slot->lock);
     /* Finalize the rest. */
     for (curr = slot->session; curr != NULL; curr = curr->next)
-        wp11_Session_Final(slot->session);
+        wp11_Session_Final(curr);
     WP11_Lock_UnlockRW(&slot->lock);
 }
 


### PR DESCRIPTION
`wc_ecc_init_ex` called twice and wrong session being finalised, along with added ForceZero usage.