### PR TITLE
Fix CI failures from upstream dependency drift

### DIFF
--- a/.github/workflows/tpm2-store-test.yml
+++ b/.github/workflows/tpm2-store-test.yml
@@ -60,7 +60,7 @@ jobs:
         repository: wolfssl/wolfssl
         ref: ${{ matrix.wolfssl_version }}
         path: wolfssl/
-        configure: --enable-all CPPFLAGS=-DWC_RSA_DIRECT
+        configure: --enable-all --disable-anon CPPFLAGS=-DWC_RSA_DIRECT
         check: false
         install: true 
 

--- a/IDE/VisualStudio/wolftpm.vcxproj
+++ b/IDE/VisualStudio/wolftpm.vcxproj
@@ -37,11 +37,13 @@
   <ItemGroup>
     <ClCompile Include="..\..\..\wolftpm\src\tpm2.c" />
     <ClCompile Include="..\..\..\wolftpm\src\tpm2_asn.c" />
+    <ClCompile Include="..\..\..\wolftpm\src\tpm2_crypto.c" />
     <ClCompile Include="..\..\..\wolftpm\src\tpm2_cryptocb.c" />
     <ClCompile Include="..\..\..\wolftpm\src\tpm2_packet.c" />
     <ClCompile Include="..\..\..\wolftpm\src\tpm2_param_enc.c" />
     <ClCompile Include="..\..\..\wolftpm\src\tpm2_swtpm.c" />
     <ClCompile Include="..\..\..\wolftpm\src\tpm2_tis.c" />
+    <ClCompile Include="..\..\..\wolftpm\src\tpm2_util.c" />
     <ClCompile Include="..\..\..\wolftpm\src\tpm2_winapi.c" />
     <ClCompile Include="..\..\..\wolftpm\src\tpm2_wrap.c" />
   </ItemGroup>


### PR DESCRIPTION
Add tpm2_crypto.c and tpm2_util.c to the wolftpm Visual Studio project. Recent wolftpm changes moved TPM2_KDFa_ex, TPM2_KDFe_ex, TPM2_AesCfbEncrypt, TPM2_HmacCompute, TPM2_HashCompute into tpm2_crypto.c and TPM2_GetHashDigestSize, TPM2_GetHashType, TPM2_ConstantCompare, TPM2_ForceZero, TPM2_PrintBin into tpm2_util.c, which caused unresolved external symbol errors on the Windows build.

Pass --disable-anon to the wolfSSL configure step in the TPM 2.0 store test workflow. wolfSSL 5.9.1 added a settings.h check that rejects HAVE_ANON without DH, and this workflow builds wolfPKCS11 with --disable-dh.