### PR TITLE
fix: update copyright years and fix configure.ac start year

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt
 #
-# Copyright (C) 2006-2024 wolfSSL Inc.
+# Copyright (C) 2006-2026 wolfSSL Inc.
 #
 # This file is part of wolfPKCS11.
 #

--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,11 @@
 # configure.ac
 #
-# Copyright (C) 2023 wolfSSL Inc.
-# All right reserved.
+# Copyright (C) 2006-2026 wolfSSL Inc.
+# All rights reserved.
 #
 # This file is part of wolfPKCS11.
 #
-AC_COPYRIGHT([Copyright (C) 2014-2023 wolfSSL Inc.])
+AC_COPYRIGHT([Copyright (C) 2006-2026 wolfSSL Inc.])
 AC_PREREQ([2.63])
 AC_INIT([wolfpkcs11],[2.1.0],[https://github.com/wolfssl/wolfpkcs11/issues],[wolfpkcs11],[http://www.wolfssl.com])
 AC_CONFIG_AUX_DIR([build-aux])
@@ -623,7 +623,7 @@ rm -f $OPTION_FILE
 echo "/* wolfpkcs11 options.h" > $OPTION_FILE
 echo " * generated from configure options" >> $OPTION_FILE
 echo " *" >> $OPTION_FILE
-echo " * Copyright (C) 2006-2023 wolfSSL Inc." >> $OPTION_FILE
+echo " * Copyright (C) 2006-2026 wolfSSL Inc." >> $OPTION_FILE
 echo " *" >> $OPTION_FILE
 echo " * * This file is part of wolfPKCS11." >> $OPTION_FILE
 echo " *" >> $OPTION_FILE

--- a/debian/copyright
+++ b/debian/copyright
@@ -6,7 +6,7 @@ Source: https://github.com/wolfSSL/wolfPKCS11/releases
 Files:
  *
 Copyright:
- 2014-2025 wolfSSL Inc.
+ 2006-2026 wolfSSL Inc.
 License: GPL-3+
 
 License: GPL-3+


### PR DESCRIPTION
## Summary

Copyright year ranges were stale and inconsistent across metadata files:

- `debian/copyright`: `2014-2025` -> `2006-2026` (start year now matches source headers)
- `configure.ac` header: added missing start year, updated to 2006-2026
- `configure.ac` AC_COPYRIGHT: `2014-2023` -> `2006-2026`
- `configure.ac` line 626 (options.h generator): `2006-2023` -> `2006-2026` (this hardcoded string bypasses license.pl)
- `CMakeLists.txt`: `2006-2024` -> `2006-2026`
- Also fixed typo "All right reserved" -> "All rights reserved" in configure.ac

No code changes -- metadata only.

## Test plan

- [ ] `grep -rn '2023\|2024\|2025' configure.ac CMakeLists.txt debian/copyright` returns no stale years
- [ ] `./autogen.sh && ./configure` still works