### PR TITLE
debian: ship cmake package config in -dev package

### DIFF
--- a/debian/libwolfpkcs11-dev.install
+++ b/debian/libwolfpkcs11-dev.install
@@ -1,3 +1,4 @@
 usr/include/
 usr/lib/*/libwolfpkcs11.so
+usr/lib/*/cmake/wolfpkcs11/*.cmake
 usr/bin/wolfpkcs11-config


### PR DESCRIPTION
The autotools build installs the CMake package-config files (`wolfpkcs11Config.cmake`, `wolfpkcs11ConfigVersion.cmake`, `wolfpkcs11Targets.cmake`) into `$(libdir)/cmake/wolfpkcs11/` (see `Makefile.am` `cmakepkgconfig_DATA`), but `debian/libwolfpkcs11-dev.install` did not capture them.

Under `debhelper-compat (= 13)`, `dh_missing` treats these orphaned files as a fatal error, so `dpkg-buildpackage` aborts during the `binary` step:

```
dh_missing: warning: usr/lib/x86_64-linux-gnu/cmake/wolfpkcs11/wolfpkcs11Config.cmake exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/lib/x86_64-linux-gnu/cmake/wolfpkcs11/wolfpkcs11ConfigVersion.cmake exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/lib/x86_64-linux-gnu/cmake/wolfpkcs11/wolfpkcs11Targets.cmake exists in debian/tmp but is not installed to anywhere
dh_missing: error: missing files, aborting
make: *** [debian/rules:21: binary] Error 25
```

This adds the cmake configs to the `-dev` package (their natural home, consumed by downstream `find_package(wolfpkcs11)`), which resolves the `dh_missing` failure.

## Test plan
- `dpkg-buildpackage -us -uc -b` on Debian 12 now completes the `binary` step; the three `.cmake` files land in `libwolfpkcs11-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)