### PR TITLE
Fix short pin tests for FIPS

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wolfpkcs11 (2.1.0) stable; urgency=medium
+
+  * For a full changelog see
+    https://github.com/wolfSSL/wolfPKCS11/blob/master/README.md
+
+ -- wolfSSL <support@wolfssl.com>  Thu, 18 Jun 2026 12:39:59 +0000
+
 wolfpkcs11 (2.0.0) stable; urgency=medium
 
   * For a full changelog see

--- a/tests/aes_cbc_pad_padding_test.c
+++ b/tests/aes_cbc_pad_padding_test.c
@@ -76,8 +76,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
 static CK_BBOOL ckTrue = CK_TRUE;

--- a/tests/aes_keygen_attrs_test.c
+++ b/tests/aes_keygen_attrs_test.c
@@ -73,8 +73,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_RV pkcs11_init(void)
 {

--- a/tests/ecb_check_value_error_test.c
+++ b/tests/ecb_check_value_error_test.c
@@ -77,8 +77,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
 static CK_BBOOL ckTrue = CK_TRUE;

--- a/tests/find_objects_null_template_test.c
+++ b/tests/find_objects_null_template_test.c
@@ -74,8 +74,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
 static CK_OBJECT_CLASS dataClass = CKO_DATA;

--- a/tests/operation_active_test.c
+++ b/tests/operation_active_test.c
@@ -74,8 +74,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
 static CK_BBOOL ckTrue = CK_TRUE;

--- a/tests/pbkdf2_keygen_attrs_test.c
+++ b/tests/pbkdf2_keygen_attrs_test.c
@@ -73,8 +73,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_RV pkcs11_init(void)
 {

--- a/tests/pkcs11_compliance_test.c
+++ b/tests/pkcs11_compliance_test.c
@@ -1093,7 +1093,7 @@ static void test_3144_private_create_requires_login(void)
     CK_OBJECT_HANDLE privKey = CK_INVALID_HANDLE;
     CK_UTF8CHAR label[32];
     CK_BYTE soPin[] = "password123456";
-    CK_BYTE userPin[] = "someUserPin";
+    CK_BYTE userPin[] = "wolfpkcs11-test";
     CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
     CK_KEY_TYPE genericKeyType = CKK_GENERIC_SECRET;
     CK_BBOOL ckTrue = CK_TRUE;
@@ -1276,7 +1276,7 @@ static void test_2370_private_default(void)
     CK_OBJECT_HANDLE pubKey = CK_INVALID_HANDLE;
     CK_OBJECT_HANDLE privKey = CK_INVALID_HANDLE;
     CK_BYTE soPin[] = "password123456";
-    CK_BYTE userPin[] = "someUserPin";
+    CK_BYTE userPin[] = "wolfpkcs11-test";
     CK_UTF8CHAR label[32];
     CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
     CK_OBJECT_CLASS pubKeyClass = CKO_PUBLIC_KEY;
@@ -1429,7 +1429,7 @@ static void test_2774_wrap_default(void)
     CK_OBJECT_HANDLE rsaPriv = CK_INVALID_HANDLE;
 #endif
     CK_BYTE soPin[] = "password123456";
-    CK_BYTE userPin[] = "someUserPin";
+    CK_BYTE userPin[] = "wolfpkcs11-test";
     CK_UTF8CHAR label[32];
     CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
     CK_KEY_TYPE aesKeyType = CKK_AES;


### PR DESCRIPTION
Some of the tests used pins too short for HMAC_FIPS_MIN_KEY. This updates the tests and also updates the Debian version to 2.1.0