### PR TITLE
Add per-job timeouts to all CI workflows

### DIFF
--- a/.github/workflows/alpine-architecture-tests.yml
+++ b/.github/workflows/alpine-architecture-tests.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   alpine-architecture-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -16,6 +16,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
 #pull wolfPKCS11

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   clang-tidy:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     if: github.repository_owner == 'wolfssl'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
 # install cmake

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   codespell:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     
     steps:
     - name: Checkout code

--- a/.github/workflows/debian-package-test.yml
+++ b/.github/workflows/debian-package-test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   debian-package-test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     
     steps:
     # Pull wolfPKCS11

--- a/.github/workflows/empty-pin-store-test.yml
+++ b/.github/workflows/empty-pin-store-test.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   empty-pin-store-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - name: Checkout wolfPKCS11

--- a/.github/workflows/firefox.yml
+++ b/.github/workflows/firefox.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test-firefox:
     runs-on: ubuntu-latest-m
+    timeout-minutes: 30
     container: wolfssl/wolfpkcs11-firefox-test:latest
     if: github.repository_owner == 'wolfssl'
     steps:

--- a/.github/workflows/nss-cmsutil-test.yml
+++ b/.github/workflows/nss-cmsutil-test.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   nss-cmsutil-test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/nss-curl-test.yml
+++ b/.github/workflows/nss-curl-test.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   test-nss-curl:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     steps:
       - name: Checkout wolfPKCS11 repository
         uses: actions/checkout@v4

--- a/.github/workflows/nss-pdfsig-test.yml
+++ b/.github/workflows/nss-pdfsig-test.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   test-nss-pdf-signing:
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
 
     steps:
     - name: Checkout wolfPKCS11 repository

--- a/.github/workflows/nss-pk12util-debian-test.yml
+++ b/.github/workflows/nss-pk12util-debian-test.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   nss-pk12util-debian-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     container:
       image: debian:bookworm
 

--- a/.github/workflows/nss-pk12util-test.yml
+++ b/.github/workflows/nss-pk12util-test.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   nss-pk12util-test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/nss-ssltap-test.yml
+++ b/.github/workflows/nss-ssltap-test.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   nss-ssltap-test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
 
     steps:
     - name: Checkout wolfPKCS11

--- a/.github/workflows/sanitizer-tests.yml
+++ b/.github/workflows/sanitizer-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   sanitizer:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false

--- a/.github/workflows/scan-build.yml
+++ b/.github/workflows/scan-build.yml
@@ -31,6 +31,7 @@ on:
 jobs:
   scan-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false

--- a/.github/workflows/storage-upgrade-test-tpm.yml
+++ b/.github/workflows/storage-upgrade-test-tpm.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   storage-upgrade-test-tpm:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         base-ref:

--- a/.github/workflows/storage-upgrade-test.yml
+++ b/.github/workflows/storage-upgrade-test.yml
@@ -10,6 +10,7 @@ env:
 jobs:
   storage-upgrade-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         base-ref:

--- a/.github/workflows/tpm2-store-test.yml
+++ b/.github/workflows/tpm2-store-test.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   get_current_wolfssl_versions:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       wolfssl_versions: ${{ steps.json.outputs.wolfssl_versions }}
     steps:
@@ -22,6 +23,7 @@ jobs:
 
   get_current_wolftpm_versions:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       wolftpm_versions: ${{ steps.json.outputs.wolftpm_versions }}
     steps:
@@ -118,6 +120,7 @@ jobs:
 
   tpm2-store-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [build_wolfssl, build_wolftpm, get_current_wolfssl_versions, get_current_wolftpm_versions]
     strategy:
       matrix:

--- a/.github/workflows/wolfssl-master-compatibility.yml
+++ b/.github/workflows/wolfssl-master-compatibility.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
 #pull wolfPKCS11
     - uses: actions/checkout@v4

--- a/.github/workflows/wolfssl-v5.6.6-build-workflow.yml
+++ b/.github/workflows/wolfssl-v5.6.6-build-workflow.yml
@@ -16,6 +16,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
 #pull wolfPKCS11


### PR DESCRIPTION
## Summary

Jobs default to GitHub's 6 hour timeout, so a hung `apt` step recently burned ~6 hours before the run failed. This adds explicit `timeout-minutes` to every job so hangs fail fast.

## Tiering

Timeouts are tiered by job weight:

- **15 min** — lint/metadata
- **30 min** — standard builds
- **60 min** — matrix analysis (clang-tidy, scan-build, sanitizers) and NSS tests
- **90 min** — QEMU-emulated Alpine builds

`unit-test.yml` calls reusable workflows, which cannot set `timeout-minutes` on the caller, so its timeout is set in `build-workflow.yml` and `wolfssl-v5.6.6-build-workflow.yml`. Pre-existing timeouts are unchanged.