### PR TITLE
PKCS11 AES-GCM/key-wrap fixes, TPM bounds check, and zeroization tests

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -3145,7 +3145,7 @@ CK_RV C_EncryptFinal(CK_SESSION_HANDLE hSession,
                 return CKR_BUFFER_TOO_SMALL;
 
             ret = WP11_AesGcm_EncryptFinal(pLastEncryptedPart, &encPartLen,
-                                                                       session);
+                                                                  obj, session);
             if (ret < 0) {
                 WP11_Session_SetOpInitialized(session, 0);
                 return CKR_FUNCTION_FAILED;

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1569,6 +1569,9 @@ CK_RV C_CopyObject(CK_SESSION_HANDLE hSession, CK_OBJECT_HANDLE hObject,
 
     keyType = WP11_Object_GetType(obj);
 
+    /* The copy inherits the source's CKA_TOKEN (PKCS#11 v2.40 4.6.2) unless
+     * the template overrides it below. */
+    onToken = WP11_Object_OnToken(obj);
     FindAttributeType(pTemplate, ulCount, CKA_TOKEN, &attr);
     if (attr != NULL) {
         if (attr->pValue == NULL)

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -2755,34 +2755,29 @@ CK_RV C_Encrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pData,
             *pulEncryptedDataLen = encDataLen;
             break;
         case CKM_AES_KEY_WRAP_PAD: {
-            byte* paddedData = NULL;
-            byte padding = KEYWRAP_BLOCK_SIZE - (ulDataLen % KEYWRAP_BLOCK_SIZE);
+            word32 padded;
 
             if (!WP11_Session_IsOpInitialized(session, WP11_INIT_AES_KEYWRAP_ENC))
                 return CKR_OPERATION_NOT_INITIALIZED;
+            if (!CK_ULONG_FITS_WORD32(ulDataLen) || ulDataLen == 0) {
+                WP11_Session_SetOpInitialized(session, 0);
+                return CKR_DATA_LEN_RANGE;
+            }
 
-            /* AES Key Wrap Pad adds up to 16 bytes for the integrity check
-             * value and padding */
-            encDataLen = (word32)(ulDataLen + KEYWRAP_BLOCK_SIZE + padding);
+            /* RFC 5649: round the input up to a multiple of 8 then add the
+             * 8-byte AIV. Aligned inputs are not over-padded. */
+            padded = ((word32)ulDataLen + KEYWRAP_BLOCK_SIZE - 1) &
+                     ~(word32)(KEYWRAP_BLOCK_SIZE - 1);
+            encDataLen = padded + KEYWRAP_BLOCK_SIZE;
             if (pEncryptedData == NULL) {
                 *pulEncryptedDataLen = encDataLen;
                 return CKR_OK;
             }
             if (encDataLen > (word32)*pulEncryptedDataLen)
                 return CKR_BUFFER_TOO_SMALL;
-            paddedData = (byte*)XMALLOC(ulDataLen + padding, NULL,
-                                        DYNAMIC_TYPE_TMP_BUFFER);
-            if (paddedData == NULL) {
-                WP11_Session_SetOpInitialized(session, 0);
-                return CKR_DEVICE_MEMORY;
-            }
-            XMEMCPY(paddedData, pData, ulDataLen);
-            XMEMSET(paddedData + ulDataLen, padding, padding);
 
-            ret = WP11_AesKeyWrap_Encrypt(paddedData, (word32)ulDataLen + padding,
+            ret = WP11_AesKeyWrapPad_Encrypt(pData, (word32)ulDataLen,
                                           pEncryptedData, &encDataLen, session);
-            wc_ForceZero(paddedData, ulDataLen + padding);
-            XFREE(paddedData, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             if (ret != 0)
                 break;
             *pulEncryptedDataLen = encDataLen;
@@ -3779,7 +3774,6 @@ CK_RV C_Decrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedData,
     #endif
     #ifdef HAVE_AES_KEYWRAP
         case CKM_AES_KEY_WRAP:
-        case CKM_AES_KEY_WRAP_PAD:
             if (!WP11_Session_IsOpInitialized(session, WP11_INIT_AES_KEYWRAP_DEC))
                 return CKR_OPERATION_NOT_INITIALIZED;
 
@@ -3801,38 +3795,33 @@ CK_RV C_Decrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedData,
                     (word32)ulEncryptedDataLen, pData, &decDataLen, session);
             if (ret != 0)
                 break;
-            if (mechanism == CKM_AES_KEY_WRAP_PAD) {
-                int i;
-                byte padValue = pData[decDataLen - 1];
-                unsigned int badPad = 0;
-                unsigned int inPad;
+            *pulDataLen = decDataLen;
+            break;
+        case CKM_AES_KEY_WRAP_PAD:
+            if (!WP11_Session_IsOpInitialized(session, WP11_INIT_AES_KEYWRAP_DEC))
+                return CKR_OPERATION_NOT_INITIALIZED;
 
-                /* Constant-time range check: padValue must be 1..KEYWRAP_BLOCK_SIZE
-                 * and must not exceed decDataLen. */
-                badPad |= ((unsigned int)padValue - 1) >> 31;
-                badPad |= ((unsigned int)KEYWRAP_BLOCK_SIZE -
-                           (unsigned int)padValue) >> 31;
-                badPad |= ((unsigned int)decDataLen -
-                           (unsigned int)padValue) >> 31;
-
-                /* Constant-time padding byte verification.
-                 * Always iterate KEYWRAP_BLOCK_SIZE times to avoid leaking
-                 * padValue through iteration count. */
-                for (i = 0; i < KEYWRAP_BLOCK_SIZE; i++) {
-                    /* Full mask: all-ones when i < padValue, else 0 */
-                    inPad = 0 - (((unsigned int)i -
-                                   (unsigned int)padValue) >> 31);
-                    badPad |= inPad &
-                              ((unsigned int)pData[decDataLen - 1 - i] ^
-                               (unsigned int)padValue);
-                }
-
-                if (badPad != 0) {
-                    ret = -1;
-                    break;
-                }
-                decDataLen -= padValue;
+            /* RFC 5649 ciphertext is at least two semiblocks and a multiple of
+             * 8. The recovered length is encoded in the AIV and is known only
+             * after unwrapping; the upper bound is ciphertext - 8. */
+            if (ulEncryptedDataLen < 2 * KEYWRAP_BLOCK_SIZE ||
+                (ulEncryptedDataLen % KEYWRAP_BLOCK_SIZE) != 0) {
+                WP11_Session_SetOpInitialized(session, 0);
+                return CKR_ENCRYPTED_DATA_LEN_RANGE;
             }
+            decDataLen = (word32)(ulEncryptedDataLen - KEYWRAP_BLOCK_SIZE);
+            if (pData == NULL) {
+                *pulDataLen = decDataLen;
+                return CKR_OK;
+            }
+            if (decDataLen > (word32)*pulDataLen)
+                return CKR_BUFFER_TOO_SMALL;
+
+            decDataLen = (word32)*pulDataLen;
+            ret = WP11_AesKeyWrapPad_Decrypt(pEncryptedData,
+                    (word32)ulEncryptedDataLen, pData, &decDataLen, session);
+            if (ret != 0)
+                break;
             *pulDataLen = decDataLen;
             break;
     #endif

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -3811,15 +3811,24 @@ CK_RV C_Decrypt(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pEncryptedData,
             }
             decDataLen = (word32)(ulEncryptedDataLen - KEYWRAP_BLOCK_SIZE);
             if (pData == NULL) {
+                /* Exact length is known only after unwrapping; report the
+                 * ciphertext - 8 upper bound for the length query. */
                 *pulDataLen = decDataLen;
                 return CKR_OK;
             }
-            if (decDataLen > (word32)*pulDataLen)
-                return CKR_BUFFER_TOO_SMALL;
 
+            /* The recovered length is not known until the AIV is decoded, so
+             * do not pre-reject against the upper bound. Unwrap into the caller
+             * buffer; if it does not fit, the unwrap reports the exact required
+             * size via decDataLen. */
             decDataLen = (word32)*pulDataLen;
             ret = WP11_AesKeyWrapPad_Decrypt(pEncryptedData,
                     (word32)ulEncryptedDataLen, pData, &decDataLen, session);
+            if (ret == BUFFER_E) {
+                *pulDataLen = decDataLen;
+                WP11_Session_SetOpInitialized(session, 0);
+                return CKR_BUFFER_TOO_SMALL;
+            }
             if (ret != 0)
                 break;
             *pulDataLen = decDataLen;

--- a/src/internal.c
+++ b/src/internal.c
@@ -7626,6 +7626,34 @@ void WP11_Slot_Logout(WP11_Slot* slot)
     WP11_Lock_UnlockRW(&slot->lock);
 }
 
+#ifdef DEBUG_WOLFPKCS11
+/**
+ * Test hook: report whether a slot's token object-encryption key is zeroized.
+ * Exposed only in debug builds so a white-box test can observe the logout
+ * scrub that has no PKCS#11-visible effect.
+ *
+ * @param  slotId  [in]  Slot id (1-based, as used by the PKCS#11 API).
+ * @return  1 when the key buffer is all zero, 0 when any byte is set,
+ *          -1 on a bad slot id.
+ */
+WP11_API int WP11_Slot_TokenKeyIsZero(CK_SLOT_ID slotId)
+{
+    WP11_Slot* slot = NULL;
+    size_t i;
+    byte acc = 0;
+
+    if (WP11_Slot_Get(slotId, &slot) != 0 || slot == NULL)
+        return -1;
+
+    WP11_Lock_LockRO(&slot->lock);
+    for (i = 0; i < sizeof(slot->token.key); i++)
+        acc |= slot->token.key[i];
+    WP11_Lock_UnlockRO(&slot->lock);
+
+    return acc == 0 ? 1 : 0;
+}
+#endif /* DEBUG_WOLFPKCS11 */
+
 /**
  * Retrieve the token's label.
  * A token's label is 32 bytes long.

--- a/src/internal.c
+++ b/src/internal.c
@@ -15639,8 +15639,11 @@ int WP11_AesKeyWrapPad_Decrypt(unsigned char* enc, word32 encSz,
         }
         if (bad)
             ret = BAD_KEYWRAP_IV_E;
-        else if (mli > *decSz)
+        else if (mli > *decSz) {
+            /* Report the required plaintext length to the caller. */
+            *decSz = mli;
             ret = BUFFER_E;
+        }
         else {
             XMEMCPY(dec, padBuf, mli);
             *decSz = mli;

--- a/src/internal.c
+++ b/src/internal.c
@@ -389,9 +389,14 @@ typedef struct WP11_GcmParams {
     unsigned char authTag[WP11_MAX_GCM_TAG_SZ];
                                        /* Authentication tag calculated       */
     unsigned char* enc;                /* Cached data for multi-part: buffered */
-                                       /* ciphertext (decrypt) or plaintext    */
-                                       /* (encrypt)                            */
+                                       /* ciphertext (decrypt) or, without     */
+                                       /* streaming GCM, plaintext (encrypt)   */
     int encSz;                         /* Size of cached data in bytes         */
+#ifdef WOLFSSL_AESGCM_STREAM
+    Aes aes;                           /* Streaming context for multi-part    */
+                                       /* encrypt                             */
+    int streamInit;                    /* Streaming context is initialized    */
+#endif
 } WP11_GcmParams;
 #endif
 
@@ -957,6 +962,12 @@ static void wp11_Session_Final(WP11_Session* session)
             XFREE(session->params.gcm.enc, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             session->params.gcm.enc = NULL;
         }
+#ifdef WOLFSSL_AESGCM_STREAM
+        if (session->params.gcm.streamInit) {
+            wc_AesFree(&session->params.gcm.aes);
+            session->params.gcm.streamInit = 0;
+        }
+#endif
     }
 #endif
 #ifdef HAVE_AESCTS
@@ -14815,6 +14826,7 @@ int WP11_AesGcm_Encrypt(unsigned char* plain, word32 plainSz,
  * @return  MEMORY_E on allocation failure.
  *          0 on success.
  */
+#ifndef WOLFSSL_AESGCM_STREAM
 static int wp11_AesGcm_BufferAppend(WP11_GcmParams* gcm, unsigned char* data,
                                     word32 dataSz)
 {
@@ -14843,24 +14855,63 @@ static int wp11_AesGcm_BufferAppend(WP11_GcmParams* gcm, unsigned char* data,
 
     return 0;
 }
+#endif /* !WOLFSSL_AESGCM_STREAM */
 
 int WP11_AesGcm_EncryptUpdate(unsigned char* plain, word32 plainSz,
                               unsigned char* enc, word32* encSz,
                               WP11_Object* secret, WP11_Session* session)
 {
+    WP11_GcmParams* gcm = &session->params.gcm;
+#ifdef WOLFSSL_AESGCM_STREAM
+    int ret;
+    WP11_Data* key;
+
+    /* Stream the segment with wolfCrypt's GCM streaming API so the whole
+     * message need not be buffered. Each update emits its own ciphertext; the
+     * tag is produced at C_EncryptFinal. */
+    if (!gcm->streamInit) {
+        ret = wc_AesInit(&gcm->aes, NULL, secret->devId);
+        if (ret == 0) {
+            if (secret->onToken)
+                WP11_Lock_LockRO(secret->lock);
+            key = secret->data.symmKey;
+            ret = wc_AesGcmInit(&gcm->aes, key->data, key->len, gcm->iv,
+                                                                    gcm->ivSz);
+            if (secret->onToken)
+                WP11_Lock_UnlockRO(secret->lock);
+        }
+        if (ret != 0)
+            return ret;
+        gcm->streamInit = 1;
+    }
+
+    /* AAD is authenticated once, on the first update. */
+    ret = wc_AesGcmEncryptUpdate(&gcm->aes, enc, plain, plainSz, gcm->aad,
+                                                                   gcm->aadSz);
+    if (ret == 0) {
+        *encSz = plainSz;
+        if (gcm->aad != NULL) {
+            XFREE(gcm->aad, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+            gcm->aad = NULL;
+            gcm->aadSz = 0;
+        }
+    }
+
+    return ret;
+#else
     int ret;
     Aes aes;
     WP11_Data* key;
-    WP11_GcmParams* gcm = &session->params.gcm;
     word32 authTagSz = gcm->tagBits / 8;
     word32 oldSz = (word32)gcm->encSz;
     unsigned char* fullEnc = NULL;
 
-    /* Buffer the plaintext and encrypt the whole accumulated message under the
-     * single IV. GCM is a stream cipher, so this segment's ciphertext is the
-     * tail of the accumulated ciphertext. Re-encrypting each update keeps the
-     * tag over the full message and the AAD authenticated until
-     * C_EncryptFinal, matching the single-shot result. */
+    /* No streaming API available: buffer the plaintext and encrypt the whole
+     * accumulated message under the single IV. GCM is a stream cipher, so this
+     * segment's ciphertext is the tail of the accumulated ciphertext.
+     * Re-encrypting each update keeps the tag over the full message and the
+     * AAD authenticated until C_EncryptFinal, matching the single-shot
+     * result. */
     ret = wp11_AesGcm_BufferAppend(gcm, plain, plainSz);
     if (ret != 0)
         return ret;
@@ -14897,6 +14948,7 @@ int WP11_AesGcm_EncryptUpdate(unsigned char* plain, word32 plainSz,
     XFREE(fullEnc, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     return ret;
+#endif /* WOLFSSL_AESGCM_STREAM */
 }
 
 /**
@@ -14920,6 +14972,39 @@ int WP11_AesGcm_EncryptFinal(unsigned char* enc, word32* encSz,
     if (*encSz < authTagSz)
         return BUFFER_E;
 
+#ifdef WOLFSSL_AESGCM_STREAM
+    {
+        WP11_Data* key;
+
+        if (!gcm->streamInit) {
+            /* No update was issued: produce the tag over the empty message. */
+            ret = wc_AesInit(&gcm->aes, NULL, secret->devId);
+            if (ret == 0) {
+                if (secret->onToken)
+                    WP11_Lock_LockRO(secret->lock);
+                key = secret->data.symmKey;
+                ret = wc_AesGcmInit(&gcm->aes, key->data, key->len, gcm->iv,
+                                                                    gcm->ivSz);
+                if (secret->onToken)
+                    WP11_Lock_UnlockRO(secret->lock);
+            }
+            if (ret == 0) {
+                gcm->streamInit = 1;
+                ret = wc_AesGcmEncryptUpdate(&gcm->aes, NULL, NULL, 0, gcm->aad,
+                                                                   gcm->aadSz);
+            }
+        }
+        if (ret == 0)
+            ret = wc_AesGcmEncryptFinal(&gcm->aes, enc, authTagSz);
+        if (ret == 0)
+            *encSz = authTagSz;
+
+        if (gcm->streamInit) {
+            wc_AesFree(&gcm->aes);
+            gcm->streamInit = 0;
+        }
+    }
+#else
     if (gcm->encSz > 0) {
         /* The final EncryptUpdate computed the tag over the whole message. */
         XMEMCPY(enc, gcm->authTag, authTagSz);
@@ -14955,6 +15040,8 @@ int WP11_AesGcm_EncryptFinal(unsigned char* enc, word32* encSz,
         gcm->enc = NULL;
     }
     gcm->encSz = 0;
+#endif /* WOLFSSL_AESGCM_STREAM */
+
     if (gcm->aad != NULL) {
         XFREE(gcm->aad, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         gcm->aad = NULL;

--- a/src/internal.c
+++ b/src/internal.c
@@ -388,8 +388,10 @@ typedef struct WP11_GcmParams {
     int tagBits;                       /* Authentication tag size in bits     */
     unsigned char authTag[WP11_MAX_GCM_TAG_SZ];
                                        /* Authentication tag calculated       */
-    unsigned char* enc;                /* Encrypted data - cached for decrypt */
-    int encSz;                         /* Size of encrypted data in bytes     */
+    unsigned char* enc;                /* Cached data for multi-part: buffered */
+                                       /* ciphertext (decrypt) or plaintext    */
+                                       /* (encrypt)                            */
+    int encSz;                         /* Size of cached data in bytes         */
 } WP11_GcmParams;
 #endif
 
@@ -14726,6 +14728,45 @@ int WP11_AesGcm_Encrypt(unsigned char* plain, word32 plainSz,
  * @return  -ve on encryption failure.
  *          0 on success.
  */
+/**
+ * Append data to the GCM accumulation buffer (gcm->enc). Used to buffer
+ * plaintext for multi-part encrypt and ciphertext for multi-part decrypt.
+ *
+ * @param  gcm     [in]  GCM parameters holding the buffer.
+ * @param  data    [in]  Data to append.
+ * @param  dataSz  [in]  Length of data in bytes.
+ * @return  MEMORY_E on allocation failure.
+ *          0 on success.
+ */
+static int wp11_AesGcm_BufferAppend(WP11_GcmParams* gcm, unsigned char* data,
+                                    word32 dataSz)
+{
+    unsigned char* newBuf;
+
+#ifdef XREALLOC
+    newBuf = (unsigned char*)XREALLOC(gcm->enc, gcm->encSz + dataSz, NULL,
+                                      DYNAMIC_TYPE_TMP_BUFFER);
+    if (newBuf == NULL)
+        return MEMORY_E;
+    gcm->enc = newBuf;
+    XMEMCPY(gcm->enc + gcm->encSz, data, dataSz);
+    gcm->encSz += dataSz;
+#else
+    newBuf = (unsigned char*)XMALLOC(gcm->encSz + dataSz, NULL,
+                                     DYNAMIC_TYPE_TMP_BUFFER);
+    if (newBuf == NULL)
+        return MEMORY_E;
+    if (gcm->enc != NULL)
+        XMEMCPY(newBuf, gcm->enc, gcm->encSz);
+    XFREE(gcm->enc, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    gcm->enc = newBuf;
+    XMEMCPY(gcm->enc + gcm->encSz, data, dataSz);
+    gcm->encSz += dataSz;
+#endif
+
+    return 0;
+}
+
 int WP11_AesGcm_EncryptUpdate(unsigned char* plain, word32 plainSz,
                               unsigned char* enc, word32* encSz,
                               WP11_Object* secret, WP11_Session* session)
@@ -14735,7 +14776,25 @@ int WP11_AesGcm_EncryptUpdate(unsigned char* plain, word32 plainSz,
     WP11_Data* key;
     WP11_GcmParams* gcm = &session->params.gcm;
     word32 authTagSz = gcm->tagBits / 8;
-    unsigned char* authTag = gcm->authTag;
+    word32 oldSz = (word32)gcm->encSz;
+    unsigned char* fullEnc = NULL;
+
+    /* Buffer the plaintext and encrypt the whole accumulated message under the
+     * single IV. GCM is a stream cipher, so this segment's ciphertext is the
+     * tail of the accumulated ciphertext. Re-encrypting each update keeps the
+     * tag over the full message and the AAD authenticated until
+     * C_EncryptFinal, matching the single-shot result. */
+    ret = wp11_AesGcm_BufferAppend(gcm, plain, plainSz);
+    if (ret != 0)
+        return ret;
+    if (gcm->encSz == 0) {
+        *encSz = 0;
+        return 0;
+    }
+
+    fullEnc = (unsigned char*)XMALLOC(gcm->encSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (fullEnc == NULL)
+        return MEMORY_E;
 
     ret = wc_AesInit(&aes, NULL, secret->devId);
     if (ret == 0) {
@@ -14747,19 +14806,18 @@ int WP11_AesGcm_EncryptUpdate(unsigned char* plain, word32 plainSz,
             WP11_Lock_UnlockRO(secret->lock);
 
         if (ret == 0)
-            ret = wc_AesGcmEncrypt(&aes, enc, plain, plainSz, gcm->iv,
-                                        gcm->ivSz, authTag, authTagSz, gcm->aad,
-                                        gcm->aadSz);
-        if (ret == 0)
+            ret = wc_AesGcmEncrypt(&aes, fullEnc, gcm->enc, (word32)gcm->encSz,
+                                        gcm->iv, gcm->ivSz, gcm->authTag,
+                                        authTagSz, gcm->aad, gcm->aadSz);
+        if (ret == 0) {
+            XMEMCPY(enc, fullEnc + oldSz, plainSz);
             *encSz = plainSz;
-
-        if (gcm->aad != NULL) {
-            XFREE(gcm->aad, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-            gcm->aad = NULL;
         }
 
         wc_AesFree(&aes);
     }
+
+    XFREE(fullEnc, NULL, DYNAMIC_TYPE_TMP_BUFFER);
 
     return ret;
 }
@@ -14776,18 +14834,55 @@ int WP11_AesGcm_EncryptUpdate(unsigned char* plain, word32 plainSz,
  *          0 on success.
  */
 int WP11_AesGcm_EncryptFinal(unsigned char* enc, word32* encSz,
-                             WP11_Session* session)
+                             WP11_Object* secret, WP11_Session* session)
 {
     int ret = 0;
     WP11_GcmParams* gcm = &session->params.gcm;
     word32 authTagSz = gcm->tagBits / 8;
 
     if (*encSz < authTagSz)
-        ret = BUFFER_E;
-    if (ret == 0) {
+        return BUFFER_E;
+
+    if (gcm->encSz > 0) {
+        /* The final EncryptUpdate computed the tag over the whole message. */
         XMEMCPY(enc, gcm->authTag, authTagSz);
         *encSz = authTagSz;
     }
+    else {
+        /* No data buffered: the tag is over the empty message and the AAD. */
+        Aes aes;
+        WP11_Data* key;
+
+        ret = wc_AesInit(&aes, NULL, secret->devId);
+        if (ret == 0) {
+            if (secret->onToken)
+                WP11_Lock_LockRO(secret->lock);
+            key = secret->data.symmKey;
+            ret = wc_AesGcmSetKey(&aes, key->data, key->len);
+            if (secret->onToken)
+                WP11_Lock_UnlockRO(secret->lock);
+
+            if (ret == 0)
+                ret = wc_AesGcmEncrypt(&aes, enc, NULL, 0, gcm->iv, gcm->ivSz,
+                                            enc, authTagSz, gcm->aad,
+                                            gcm->aadSz);
+            if (ret == 0)
+                *encSz = authTagSz;
+
+            wc_AesFree(&aes);
+        }
+    }
+
+    if (gcm->enc != NULL) {
+        XFREE(gcm->enc, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        gcm->enc = NULL;
+    }
+    gcm->encSz = 0;
+    if (gcm->aad != NULL) {
+        XFREE(gcm->aad, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        gcm->aad = NULL;
+    }
+    gcm->aadSz = 0;
 
     return ret;
 }

--- a/src/internal.c
+++ b/src/internal.c
@@ -3633,7 +3633,10 @@ static int WP11_Object_DecodeTpmKey(WP11_Object* object)
     word32 idx = 0;
     word32 keyDataLen;
     UINT16 pubAreaSize = 0;
-    byte pubAreaBuffer[sizeof(TPM2B_PUBLIC)];
+    /* Largest valid marshalled public area: the TPM2B_PUBLIC payload, i.e. the
+     * structure without its UINT16 size prefix. */
+    const word32 maxPubAreaSize = (word32)sizeof(TPM2B_PUBLIC) -
+                                  (word32)sizeof(UINT16);
 
     if (object == NULL || object->keyData == NULL || object->slot == NULL) {
         return BAD_FUNC_ARG;
@@ -3651,7 +3654,7 @@ static int WP11_Object_DecodeTpmKey(WP11_Object* object)
         return BUFFER_E;
     XMEMCPY(&pubAreaSize, object->keyData, sizeof(pubAreaSize));
     idx += sizeof(pubAreaSize);
-    if (pubAreaSize <= (UINT16)sizeof(pubAreaBuffer)) {
+    if ((word32)pubAreaSize <= maxPubAreaSize) {
         /* Parse public. The public blob is sizeof(UINT16) + pubAreaSize bytes;
          * pass the remaining keyData length so the parser cannot read past the
          * blob. */

--- a/src/internal.c
+++ b/src/internal.c
@@ -15293,6 +15293,202 @@ int WP11_AesKeyWrap_Decrypt(unsigned char* enc, word32 encSz,
     *decSz = ret;
     return 0;
 }
+
+/**
+ * RFC 3394 key unwrap core that returns the recovered integrity register A
+ * instead of verifying it, so RFC 5649 can inspect the AIV (which encodes the
+ * length being recovered). Mirrors wc_AesKeyUnWrap_ex. The padded plaintext
+ * (inSz - 8 bytes) is written to out and the recovered A to aOut.
+ */
+static int wp11_AesKeyUnwrapRaw(Aes* aes, const unsigned char* in, word32 inSz,
+        unsigned char* out, unsigned char* aOut)
+{
+    unsigned char a[KEYWRAP_BLOCK_SIZE];
+    unsigned char t[KEYWRAP_BLOCK_SIZE];
+    unsigned char tmp[2 * KEYWRAP_BLOCK_SIZE];
+    unsigned char* r;
+    word32 n = (inSz / KEYWRAP_BLOCK_SIZE) - 1;
+    word32 i;
+    word32 cnt = 6 * n;
+    int j, k;
+    int ret = 0;
+
+    XMEMCPY(a, in, KEYWRAP_BLOCK_SIZE);
+    XMEMCPY(out, in + KEYWRAP_BLOCK_SIZE, inSz - KEYWRAP_BLOCK_SIZE);
+
+    /* t = 6n as a big-endian 64-bit counter. */
+    XMEMSET(t, 0, sizeof(t));
+    t[7] = (unsigned char)(cnt);
+    t[6] = (unsigned char)(cnt >> 8);
+    t[5] = (unsigned char)(cnt >> 16);
+    t[4] = (unsigned char)(cnt >> 24);
+
+    for (j = 5; j >= 0; j--) {
+        for (i = n; i >= 1; i--) {
+            /* A ^= t */
+            for (k = 0; k < KEYWRAP_BLOCK_SIZE; k++)
+                a[k] ^= t[k];
+            /* t-- */
+            for (k = KEYWRAP_BLOCK_SIZE - 1; k >= 0; k--) {
+                t[k]--;
+                if (t[k] != 0xFF)
+                    break;
+            }
+            r = out + (i - 1) * KEYWRAP_BLOCK_SIZE;
+            XMEMCPY(tmp, a, KEYWRAP_BLOCK_SIZE);
+            XMEMCPY(tmp + KEYWRAP_BLOCK_SIZE, r, KEYWRAP_BLOCK_SIZE);
+            ret = wc_AesDecryptDirect(aes, tmp, tmp);
+            if (ret != 0)
+                break;
+            XMEMCPY(a, tmp, KEYWRAP_BLOCK_SIZE);
+            XMEMCPY(r, tmp + KEYWRAP_BLOCK_SIZE, KEYWRAP_BLOCK_SIZE);
+        }
+        if (ret != 0)
+            break;
+    }
+
+    XMEMCPY(aOut, a, KEYWRAP_BLOCK_SIZE);
+    wc_ForceZero(tmp, sizeof(tmp));
+    return ret;
+}
+
+/* RFC 5649 AIV fixed prefix. */
+static const unsigned char wp11_kwp_aiv[4] = { 0xA6, 0x59, 0x59, 0xA6 };
+
+/**
+ * AES Key Wrap with Padding (RFC 5649) - wrap direction.
+ * Wraps plainSz (>= 1) bytes from plain into enc. On success *encSz is set to
+ * the wrapped length, roundup8(plainSz) + 8 bytes.
+ */
+int WP11_AesKeyWrapPad_Encrypt(unsigned char* plain, word32 plainSz,
+        unsigned char* enc, word32* encSz, WP11_Session* session)
+{
+    int ret = 0;
+    WP11_KeyWrapParams *wrap = &session->params.kw;
+    word32 padded = (plainSz + KEYWRAP_BLOCK_SIZE - 1) &
+                    ~(word32)(KEYWRAP_BLOCK_SIZE - 1);
+    word32 outLen = padded + KEYWRAP_BLOCK_SIZE;
+    unsigned char aiv[KEYWRAP_BLOCK_SIZE];
+    unsigned char* buf = NULL;
+
+    if (plainSz == 0)
+        ret = BAD_FUNC_ARG;
+    if (ret == 0 && *encSz < outLen)
+        ret = BUFFER_E;
+    if (ret == 0) {
+        buf = (unsigned char*)XMALLOC(padded, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (buf == NULL)
+            ret = MEMORY_E;
+    }
+    if (ret == 0) {
+        /* AIV = A65959A6 || MLI (big-endian 32-bit plaintext length). */
+        XMEMCPY(aiv, wp11_kwp_aiv, sizeof(wp11_kwp_aiv));
+        aiv[4] = (unsigned char)(plainSz >> 24);
+        aiv[5] = (unsigned char)(plainSz >> 16);
+        aiv[6] = (unsigned char)(plainSz >> 8);
+        aiv[7] = (unsigned char)(plainSz);
+
+        XMEMCPY(buf, plain, plainSz);
+        XMEMSET(buf + plainSz, 0, padded - plainSz);
+
+        if (padded == KEYWRAP_BLOCK_SIZE) {
+            /* Single semiblock: ECB-encrypt AIV || padded plaintext. */
+            unsigned char block[2 * KEYWRAP_BLOCK_SIZE];
+            XMEMCPY(block, aiv, KEYWRAP_BLOCK_SIZE);
+            XMEMCPY(block + KEYWRAP_BLOCK_SIZE, buf, KEYWRAP_BLOCK_SIZE);
+            ret = wc_AesEncryptDirect(&wrap->aes, enc, block);
+            wc_ForceZero(block, sizeof(block));
+        }
+        else {
+            /* Multi-block: RFC 3394 wrap with the AIV as the initial value. */
+            ret = wc_AesKeyWrap_ex(&wrap->aes, buf, padded, enc, *encSz, aiv);
+            if (ret >= 0)
+                ret = 0;
+        }
+        if (ret == 0)
+            *encSz = outLen;
+    }
+
+    if (buf != NULL) {
+        wc_ForceZero(buf, padded);
+        XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    wc_AesFree(&wrap->aes);
+    session->init = 0;
+    return ret;
+}
+
+/**
+ * AES Key Wrap with Padding (RFC 5649) - unwrap direction.
+ * Recovers the original plaintext from enc into dec. On success *decSz is set to
+ * the recovered plaintext length.
+ */
+int WP11_AesKeyWrapPad_Decrypt(unsigned char* enc, word32 encSz,
+        unsigned char* dec, word32* decSz, WP11_Session* session)
+{
+    int ret = 0;
+    WP11_KeyWrapParams *wrap = &session->params.kw;
+    unsigned char aiv[KEYWRAP_BLOCK_SIZE];
+    unsigned char* padBuf = NULL;
+    word32 paddedSz = encSz - KEYWRAP_BLOCK_SIZE;
+    word32 mli = 0;
+    word32 i;
+    int bad = 0;
+
+    if (encSz < 2 * KEYWRAP_BLOCK_SIZE || (encSz % KEYWRAP_BLOCK_SIZE) != 0)
+        return BUFFER_E;
+
+    padBuf = (unsigned char*)XMALLOC(paddedSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (padBuf == NULL)
+        return MEMORY_E;
+
+    if (encSz == 2 * KEYWRAP_BLOCK_SIZE) {
+        /* Single semiblock: ECB-decrypt to AIV || padded plaintext. */
+        unsigned char block[2 * KEYWRAP_BLOCK_SIZE];
+        ret = wc_AesDecryptDirect(&wrap->aes, block, enc);
+        if (ret == 0) {
+            XMEMCPY(aiv, block, KEYWRAP_BLOCK_SIZE);
+            XMEMCPY(padBuf, block + KEYWRAP_BLOCK_SIZE, KEYWRAP_BLOCK_SIZE);
+        }
+        wc_ForceZero(block, sizeof(block));
+    }
+    else {
+        /* Multi-block: RFC 3394 unwrap recovering the AIV. */
+        ret = wp11_AesKeyUnwrapRaw(&wrap->aes, enc, encSz, padBuf, aiv);
+    }
+
+    if (ret == 0) {
+        /* Verify the AIV prefix and recover the message length indicator. */
+        if (XMEMCMP(aiv, wp11_kwp_aiv, sizeof(wp11_kwp_aiv)) != 0)
+            bad = 1;
+        mli = ((word32)aiv[4] << 24) | ((word32)aiv[5] << 16) |
+              ((word32)aiv[6] << 8) | (word32)aiv[7];
+        /* roundup8(mli) must equal paddedSz: paddedSz-8 < mli <= paddedSz. */
+        if (mli > paddedSz || mli + KEYWRAP_BLOCK_SIZE <= paddedSz)
+            bad = 1;
+        if (!bad) {
+            /* Padding octets must be zero. */
+            for (i = mli; i < paddedSz; i++) {
+                if (padBuf[i] != 0)
+                    bad = 1;
+            }
+        }
+        if (bad)
+            ret = BAD_KEYWRAP_IV_E;
+        else if (mli > *decSz)
+            ret = BUFFER_E;
+        else {
+            XMEMCPY(dec, padBuf, mli);
+            *decSz = mli;
+        }
+    }
+
+    wc_ForceZero(padBuf, paddedSz);
+    XFREE(padBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    wc_AesFree(&wrap->aes);
+    session->init = 0;
+    return ret;
+}
 #endif /* HAVE_AES_KEYWRAP */
 
 #ifdef HAVE_AESCTS

--- a/src/internal.c
+++ b/src/internal.c
@@ -3620,31 +3620,48 @@ static int WP11_Object_DecodeTpmKey(WP11_Object* object)
 {
     int ret = 0;
     word32 idx = 0;
+    word32 keyDataLen;
     UINT16 pubAreaSize = 0;
     byte pubAreaBuffer[sizeof(TPM2B_PUBLIC)];
 
     if (object == NULL || object->keyData == NULL || object->slot == NULL) {
         return BAD_FUNC_ARG;
     }
+    /* keyData is loaded from on-disk storage and is not covered by the token
+     * master key, so treat keyDataLen as untrusted and bounds-check every
+     * read against it. Layout: pubAreaSize | public(2+pubAreaSize) |
+     * priv.size | priv.buffer(priv.size). */
+    if (object->keyDataLen < 0)
+        return BUFFER_E;
+    keyDataLen = (word32)object->keyDataLen;
 
     /* Extract public size */
+    if (keyDataLen < idx + (word32)sizeof(pubAreaSize))
+        return BUFFER_E;
     XMEMCPY(&pubAreaSize, object->keyData, sizeof(pubAreaSize));
     idx += sizeof(pubAreaSize);
     if (pubAreaSize <= (UINT16)sizeof(pubAreaBuffer)) {
-        /* Parse public */
-        /* TODO: pass: sizeof(UINT16) + pubAreaSize (see wolfTPM PR 419) */
+        /* Parse public. The public blob is sizeof(UINT16) + pubAreaSize bytes;
+         * pass the remaining keyData length so the parser cannot read past the
+         * blob. */
         int parsedPubSize = pubAreaSize;
+        if (keyDataLen < idx + (word32)sizeof(UINT16) + (word32)pubAreaSize)
+            return BUFFER_E;
         ret = TPM2_ParsePublic(&object->tpmKey->pub, object->keyData + idx,
-            sizeof(object->tpmKey->pub), &parsedPubSize);
+            keyDataLen - idx, &parsedPubSize);
         if (ret == 0) {
             idx += sizeof(UINT16) + pubAreaSize;
 
+            if (keyDataLen < idx + (word32)sizeof(object->tpmKey->priv.size))
+                return BUFFER_E;
             XMEMCPY(&object->tpmKey->priv.size, object->keyData + idx,
                 sizeof(object->tpmKey->priv.size));
             if (object->tpmKey->priv.size <
                                     (int)sizeof(object->tpmKey->priv.buffer)) {
                 idx += sizeof(object->tpmKey->priv.size);
                 /* Extract private size and private */
+                if (keyDataLen < idx + (word32)object->tpmKey->priv.size)
+                    return BUFFER_E;
                 XMEMCPY(object->tpmKey->priv.buffer, object->keyData + idx,
                     object->tpmKey->priv.size);
             }
@@ -3683,6 +3700,38 @@ static int WP11_Object_DecodeTpmKey(WP11_Object* object)
 
     return ret;
 }
+
+#ifdef DEBUG_WOLFPKCS11
+/**
+ * Test hook: run WP11_Object_DecodeTpmKey against a caller-supplied keyData
+ * blob to exercise the storage-blob bounds checks without a live TPM. A
+ * truncated blob must return BUFFER_E rather than read past the buffer.
+ *
+ * @param  slotId      [in]  Slot id (1-based).
+ * @param  keyData     [in]  Encoded TPM key blob (possibly truncated).
+ * @param  keyDataLen  [in]  Length of keyData in bytes.
+ * @return  decode status; BUFFER_E for a short/truncated blob.
+ */
+WP11_API int WP11_Test_DecodeTpmKey(CK_SLOT_ID slotId, unsigned char* keyData,
+    int keyDataLen)
+{
+    WP11_Slot* slot = NULL;
+    WP11_Object object;
+    WOLFTPM2_KEYBLOB blob;
+
+    if (WP11_Slot_Get(slotId, &slot) != 0 || slot == NULL)
+        return BAD_FUNC_ARG;
+
+    XMEMSET(&object, 0, sizeof(object));
+    XMEMSET(&blob, 0, sizeof(blob));
+    object.slot = slot;
+    object.tpmKey = &blob;
+    object.keyData = keyData;
+    object.keyDataLen = keyDataLen;
+
+    return WP11_Object_DecodeTpmKey(&object);
+}
+#endif /* DEBUG_WOLFPKCS11 */
 
 static int WP11_Object_WrapTpmKey(WP11_Object* object); /* forward declaration */
 

--- a/tests/aes_gcm_multipart_test.c
+++ b/tests/aes_gcm_multipart_test.c
@@ -89,8 +89,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
 static CK_BBOOL ckTrue = CK_TRUE;

--- a/tests/aes_gcm_multipart_test.c
+++ b/tests/aes_gcm_multipart_test.c
@@ -1,0 +1,561 @@
+/* aes_gcm_multipart_test.c
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfPKCS11.
+ *
+ * wolfPKCS11 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfPKCS11 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ *
+ * Test for CKM_AES_GCM multi-part vs single-shot equivalence (bug #4068).
+ *
+ * The buggy C_EncryptUpdate re-ran the one-shot wc_AesGcmEncrypt per call,
+ * reusing the IV for every segment, authenticating only the last segment and
+ * dropping AAD after the first segment. The multi-part ciphertext+tag therefore
+ * differed from the single-shot result whenever more than one update was issued.
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
+#include <stdio.h>
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/misc.h>
+
+#ifndef WOLFPKCS11_USER_SETTINGS
+    #include <wolfpkcs11/options.h>
+#endif
+#include <wolfpkcs11/pkcs11.h>
+
+#ifndef HAVE_PKCS11_STATIC
+#include <dlfcn.h>
+#endif
+
+#include "testdata.h"
+
+#if !defined(NO_AES) && defined(HAVE_AESGCM)
+
+#define GCM_MP_TEST_DIR "./store/aes_gcm_multipart_test"
+#define WOLFPKCS11_TOKEN_FILENAME "wp11_token_0000000000000001"
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+#define CHECK_CKR(rv, op, expected) do {                    \
+    if (rv != expected) {                                   \
+        fprintf(stderr, "FAIL: %s: expected %ld, got %ld\n", op, (long)expected, (long)rv); \
+        test_failed++;                                      \
+        result = -1;                                        \
+        goto cleanup;                                       \
+    } else {                                                \
+        printf("PASS: %s\n", op);                           \
+        test_passed++;                                      \
+    }                                                       \
+} while(0)
+
+#define CHECK_COND(cond, op) do {                           \
+    if (!(cond)) {                                          \
+        fprintf(stderr, "FAIL: %s\n", op);                 \
+        test_failed++;                                      \
+        result = -1;                                        \
+        goto cleanup;                                       \
+    } else {                                                \
+        printf("PASS: %s\n", op);                           \
+        test_passed++;                                      \
+    }                                                       \
+} while(0)
+
+#ifndef HAVE_PKCS11_STATIC
+static void* dlib;
+#endif
+static CK_FUNCTION_LIST* funcList;
+static CK_SLOT_ID slot = 0;
+static const char* tokenName = "wolfpkcs11";
+static byte* soPin = (byte*)"password123456";
+static int soPinLen = 14;
+static byte* userPin = (byte*)"someUserPin";
+static int userPinLen = 11;
+
+static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
+static CK_BBOOL ckTrue = CK_TRUE;
+static CK_KEY_TYPE aesKeyType = CKK_AES;
+
+static CK_RV pkcs11_init(void)
+{
+    CK_RV ret;
+    CK_C_INITIALIZE_ARGS args;
+    CK_SLOT_ID slotList[16];
+    CK_ULONG slotCount = sizeof(slotList) / sizeof(slotList[0]);
+
+#ifndef HAVE_PKCS11_STATIC
+    CK_C_GetFunctionList func;
+
+    dlib = dlopen(WOLFPKCS11_DLL_FILENAME, RTLD_NOW | RTLD_LOCAL);
+    if (dlib == NULL) {
+        fprintf(stderr, "dlopen error: %s\n", dlerror());
+        return -1;
+    }
+
+    func = (CK_C_GetFunctionList)dlsym(dlib, "C_GetFunctionList");
+    if (func == NULL) {
+        fprintf(stderr, "Failed to get function list function\n");
+        dlclose(dlib);
+        return -1;
+    }
+
+    ret = func(&funcList);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "Failed to get function list: 0x%lx\n",
+            (unsigned long)ret);
+        dlclose(dlib);
+        return ret;
+    }
+#else
+    ret = C_GetFunctionList(&funcList);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "Failed to get function list: 0x%lx\n",
+            (unsigned long)ret);
+        return ret;
+    }
+#endif
+
+    XMEMSET(&args, 0, sizeof(args));
+    args.flags = CKF_OS_LOCKING_OK;
+    ret = funcList->C_Initialize(&args);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_GetSlotList(CK_TRUE, slotList, &slotCount);
+    if (ret != CKR_OK)
+        return ret;
+
+    if (slotCount > 0) {
+        slot = slotList[0];
+    } else {
+        fprintf(stderr, "No slots available\n");
+        return CKR_GENERAL_ERROR;
+    }
+
+    return ret;
+}
+
+static CK_RV pkcs11_final(void)
+{
+    if (funcList != NULL) {
+        funcList->C_Finalize(NULL);
+        funcList = NULL;
+    }
+#ifndef HAVE_PKCS11_STATIC
+    if (dlib) {
+        dlclose(dlib);
+        dlib = NULL;
+    }
+#endif
+    return CKR_OK;
+}
+
+static CK_RV pkcs11_init_token(void)
+{
+    unsigned char label[32];
+
+    XMEMSET(label, ' ', sizeof(label));
+    XMEMCPY(label, tokenName, XSTRLEN(tokenName));
+
+    return funcList->C_InitToken(slot, soPin, soPinLen, label);
+}
+
+static CK_RV pkcs11_set_user_pin(void)
+{
+    CK_SESSION_HANDLE soSession;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+    CK_RV ret;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, &soSession);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_Login(soSession, CKU_SO, soPin, soPinLen);
+    if (ret != CKR_OK) {
+        funcList->C_CloseSession(soSession);
+        return ret;
+    }
+
+    ret = funcList->C_InitPIN(soSession, userPin, userPinLen);
+    funcList->C_Logout(soSession);
+    funcList->C_CloseSession(soSession);
+    return ret;
+}
+
+static CK_RV pkcs11_open_session(CK_SESSION_HANDLE* session)
+{
+    CK_RV ret;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, session);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_Login(*session, CKU_USER, userPin, userPinLen);
+    if (ret != CKR_OK) {
+        funcList->C_CloseSession(*session);
+        return ret;
+    }
+
+    return CKR_OK;
+}
+
+static CK_RV pkcs11_close_session(CK_SESSION_HANDLE session)
+{
+    funcList->C_Logout(session);
+    return funcList->C_CloseSession(session);
+}
+
+static void cleanup_test_files(const char* dir)
+{
+    char filepath[512];
+
+    snprintf(filepath, sizeof(filepath), "%s" PATH_SEP "%s", dir,
+             WOLFPKCS11_TOKEN_FILENAME);
+    (void)remove(filepath);
+}
+
+static CK_RV create_aes_key(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE* key)
+{
+    CK_ATTRIBUTE tmpl[] = {
+        { CKA_CLASS,    &secretKeyClass, sizeof(secretKeyClass) },
+        { CKA_KEY_TYPE, &aesKeyType,     sizeof(aesKeyType)     },
+        { CKA_ENCRYPT,  &ckTrue,         sizeof(ckTrue)         },
+        { CKA_DECRYPT,  &ckTrue,         sizeof(ckTrue)         },
+        { CKA_VALUE,    aes_128_key,     sizeof(aes_128_key)    },
+        { CKA_TOKEN,    &ckTrue,         sizeof(ckTrue)         },
+    };
+    CK_ULONG tmplCnt = sizeof(tmpl) / sizeof(*tmpl);
+
+    return funcList->C_CreateObject(session, tmpl, tmplCnt, key);
+}
+
+static void init_gcm_mech(CK_MECHANISM* mech, CK_GCM_PARAMS* params,
+                          CK_BYTE* iv, CK_ULONG ivLen, CK_BYTE* aad,
+                          CK_ULONG aadLen, CK_ULONG tagBits)
+{
+    params->pIv       = iv;
+    params->ulIvLen   = ivLen;
+    params->pAAD      = aad;
+    params->ulAADLen  = aadLen;
+    params->ulTagBits = tagBits;
+
+    mech->mechanism      = CKM_AES_GCM;
+    mech->ulParameterLen = sizeof(*params);
+    mech->pParameter     = params;
+}
+
+/* Single-shot encrypt of the whole plaintext. */
+static CK_RV gcm_single(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
+                        CK_BYTE* iv, CK_ULONG ivLen, CK_BYTE* aad,
+                        CK_ULONG aadLen, CK_ULONG tagBits, CK_BYTE* plain,
+                        CK_ULONG plainLen, CK_BYTE* out, CK_ULONG* outLen)
+{
+    CK_MECHANISM mech;
+    CK_GCM_PARAMS params;
+    CK_RV ret;
+
+    init_gcm_mech(&mech, &params, iv, ivLen, aad, aadLen, tagBits);
+    ret = funcList->C_EncryptInit(session, &mech, key);
+    if (ret != CKR_OK)
+        return ret;
+    return funcList->C_Encrypt(session, plain, plainLen, out, outLen);
+}
+
+/*
+ * Encrypt the same plaintext split into npart segments via
+ * C_EncryptUpdate/C_EncryptFinal and compare the concatenated result with the
+ * single-shot ciphertext+tag.
+ */
+static int gcm_multipart_equiv(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
+                               CK_BYTE* aad, CK_ULONG aadLen,
+                               const CK_ULONG* parts, int nparts,
+                               const char* label)
+{
+    CK_MECHANISM mech;
+    CK_GCM_PARAMS params;
+    CK_RV ret;
+    CK_BYTE iv[12];
+    CK_BYTE plain[64];
+    CK_BYTE single[sizeof(plain) + 16];
+    CK_BYTE multi[sizeof(plain) + 16];
+    CK_ULONG singleLen, multiLen, off, plainLen, i;
+    CK_ULONG tagBits = 128;
+    int p;
+    int result = 0;
+    char msg[128];
+
+    XMEMSET(iv, 7, sizeof(iv));
+    for (i = 0; i < sizeof(plain); i++)
+        plain[i] = (CK_BYTE)(i * 3 + 1);
+
+    plainLen = 0;
+    for (p = 0; p < nparts; p++)
+        plainLen += parts[p];
+
+    /* Single-shot reference */
+    singleLen = sizeof(single);
+    ret = gcm_single(session, key, iv, sizeof(iv), aad, aadLen, tagBits,
+                     plain, plainLen, single, &singleLen);
+    snprintf(msg, sizeof(msg), "%s: single-shot C_Encrypt", label);
+    CHECK_CKR(ret, msg, CKR_OK);
+
+    /* Multi-part */
+    init_gcm_mech(&mech, &params, iv, sizeof(iv), aad, aadLen, tagBits);
+    ret = funcList->C_EncryptInit(session, &mech, key);
+    snprintf(msg, sizeof(msg), "%s: multi-part C_EncryptInit", label);
+    CHECK_CKR(ret, msg, CKR_OK);
+
+    off = 0;
+    multiLen = 0;
+    for (p = 0; p < nparts; p++) {
+        CK_ULONG partOut = sizeof(multi) - multiLen;
+        ret = funcList->C_EncryptUpdate(session, plain + off, parts[p],
+                                        multi + multiLen, &partOut);
+        snprintf(msg, sizeof(msg), "%s: C_EncryptUpdate part %d", label, p);
+        CHECK_CKR(ret, msg, CKR_OK);
+        off += parts[p];
+        multiLen += partOut;
+    }
+
+    {
+        CK_ULONG tagOut = sizeof(multi) - multiLen;
+        ret = funcList->C_EncryptFinal(session, multi + multiLen, &tagOut);
+        snprintf(msg, sizeof(msg), "%s: C_EncryptFinal", label);
+        CHECK_CKR(ret, msg, CKR_OK);
+        multiLen += tagOut;
+    }
+
+    snprintf(msg, sizeof(msg), "%s: multi-part length equals single-shot",
+             label);
+    CHECK_COND(multiLen == singleLen, msg);
+
+    snprintf(msg, sizeof(msg), "%s: multi-part bytes equal single-shot", label);
+    CHECK_COND(XMEMCMP(multi, single, singleLen) == 0, msg);
+
+    /* The multi-part output must also decrypt back to the plaintext via the
+     * single-shot path, proving the tag authenticates the whole message. */
+    init_gcm_mech(&mech, &params, iv, sizeof(iv), aad, aadLen, tagBits);
+    ret = funcList->C_DecryptInit(session, &mech, key);
+    snprintf(msg, sizeof(msg), "%s: C_DecryptInit", label);
+    CHECK_CKR(ret, msg, CKR_OK);
+
+    {
+        CK_BYTE dec[sizeof(plain)];
+        CK_ULONG decLen = sizeof(dec);
+        ret = funcList->C_Decrypt(session, multi, multiLen, dec, &decLen);
+        snprintf(msg, sizeof(msg), "%s: C_Decrypt multi-part output", label);
+        CHECK_CKR(ret, msg, CKR_OK);
+        snprintf(msg, sizeof(msg), "%s: decrypted plaintext matches", label);
+        CHECK_COND(decLen == plainLen && XMEMCMP(dec, plain, plainLen) == 0,
+                   msg);
+    }
+
+cleanup:
+    return result;
+}
+
+/*
+ * Empty message: C_EncryptInit followed directly by C_EncryptFinal (no update)
+ * must emit a tag over the empty message + AAD that authenticates on decrypt.
+ * The single-shot C_Encrypt path rejects a zero-length input, so this checks a
+ * self-consistent round-trip rather than comparing against single-shot.
+ */
+static int gcm_empty_final(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE key,
+                           CK_BYTE* aad, CK_ULONG aadLen, const char* label)
+{
+    CK_MECHANISM mech;
+    CK_GCM_PARAMS params;
+    CK_RV ret;
+    CK_BYTE iv[12];
+    CK_BYTE tag[16];
+    CK_BYTE dec[16];
+    CK_ULONG tagLen = sizeof(tag);
+    CK_ULONG decLen = sizeof(dec);
+    int result = 0;
+    char msg[128];
+
+    XMEMSET(iv, 9, sizeof(iv));
+
+    init_gcm_mech(&mech, &params, iv, sizeof(iv), aad, aadLen, 128);
+    ret = funcList->C_EncryptInit(session, &mech, key);
+    snprintf(msg, sizeof(msg), "%s: empty C_EncryptInit", label);
+    CHECK_CKR(ret, msg, CKR_OK);
+
+    ret = funcList->C_EncryptFinal(session, tag, &tagLen);
+    snprintf(msg, sizeof(msg), "%s: empty C_EncryptFinal", label);
+    CHECK_CKR(ret, msg, CKR_OK);
+
+    snprintf(msg, sizeof(msg), "%s: empty final emits full tag", label);
+    CHECK_COND(tagLen == sizeof(tag), msg);
+
+    /* Decrypting just the tag (zero ciphertext) must authenticate. */
+    init_gcm_mech(&mech, &params, iv, sizeof(iv), aad, aadLen, 128);
+    ret = funcList->C_DecryptInit(session, &mech, key);
+    snprintf(msg, sizeof(msg), "%s: empty C_DecryptInit", label);
+    CHECK_CKR(ret, msg, CKR_OK);
+
+    ret = funcList->C_Decrypt(session, tag, tagLen, dec, &decLen);
+    snprintf(msg, sizeof(msg), "%s: empty C_Decrypt of tag", label);
+    CHECK_CKR(ret, msg, CKR_OK);
+
+    snprintf(msg, sizeof(msg), "%s: empty message decrypts to zero bytes",
+             label);
+    CHECK_COND(decLen == 0, msg);
+
+cleanup:
+    return result;
+}
+
+static int aes_gcm_multipart_test(void)
+{
+    CK_RV ret;
+    CK_SESSION_HANDLE session = 0;
+    CK_OBJECT_HANDLE key = CK_INVALID_HANDLE;
+    int result = 0;
+    CK_BYTE aad[20];
+    CK_ULONG i;
+    /* Various splits, all with >= 2 non-empty parts (the broken case). */
+    CK_ULONG twoEven[2]  = { 16, 16 };
+    CK_ULONG twoOdd[2]   = { 5, 27 };
+    CK_ULONG three[3]    = { 8, 8, 16 };
+    CK_ULONG four[4]     = { 10, 10, 10, 2 };
+
+    printf("\n=== Testing CKM_AES_GCM multi-part equivalence ===\n");
+
+    cleanup_test_files(GCM_MP_TEST_DIR);
+
+    for (i = 0; i < sizeof(aad); i++)
+        aad[i] = (CK_BYTE)(0x40 + i);
+
+    ret = pkcs11_init();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: pkcs11_init: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        return -1;
+    }
+
+    ret = pkcs11_init_token();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: C_InitToken: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+
+    ret = pkcs11_set_user_pin();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: set user PIN: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+
+    ret = pkcs11_open_session(&session);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: pkcs11_open_session: 0x%lx\n",
+                (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+
+    ret = create_aes_key(session, &key);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: create_aes_key: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_close_session(session);
+        pkcs11_final();
+        return -1;
+    }
+
+    /* Without AAD */
+    if (gcm_multipart_equiv(session, key, NULL, 0, twoEven, 2,
+                            "no-aad 16+16") != 0)
+        result = -1;
+    if (gcm_multipart_equiv(session, key, NULL, 0, twoOdd, 2,
+                            "no-aad 5+27") != 0)
+        result = -1;
+    if (gcm_multipart_equiv(session, key, NULL, 0, three, 3,
+                            "no-aad 8+8+16") != 0)
+        result = -1;
+    /* With AAD (exercises the AAD-dropped-after-first-update bug) */
+    if (gcm_multipart_equiv(session, key, aad, sizeof(aad), twoEven, 2,
+                            "aad 16+16") != 0)
+        result = -1;
+    if (gcm_multipart_equiv(session, key, aad, sizeof(aad), four, 4,
+                            "aad 10+10+10+2") != 0)
+        result = -1;
+    /* Empty message (no update before final) */
+    if (gcm_empty_final(session, key, NULL, 0, "empty no-aad") != 0)
+        result = -1;
+    if (gcm_empty_final(session, key, aad, sizeof(aad), "empty aad") != 0)
+        result = -1;
+
+    pkcs11_close_session(session);
+    pkcs11_final();
+    return result;
+}
+
+static void print_results(void)
+{
+    printf("\n=== Test Results ===\n");
+    printf("Tests passed: %d\n", test_passed);
+    printf("Tests failed: %d\n", test_failed);
+
+    if (test_failed == 0)
+        printf("ALL TESTS PASSED!\n");
+    else
+        printf("SOME TESTS FAILED!\n");
+}
+
+int main(int argc, char* argv[])
+{
+#ifndef WOLFPKCS11_NO_ENV
+    XSETENV("WOLFPKCS11_TOKEN_PATH", GCM_MP_TEST_DIR, 1);
+#endif
+
+    (void)argc;
+    (void)argv;
+
+    printf("=== wolfPKCS11 AES-GCM Multi-part Equivalence Test ===\n");
+
+    (void)aes_gcm_multipart_test();
+
+    print_results();
+
+    return (test_failed == 0) ? 0 : 1;
+}
+
+#else /* NO_AES || !HAVE_AESGCM */
+
+int main(int argc, char* argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("AES-GCM not available, skipping multi-part equivalence test\n");
+    return 0;
+}
+
+#endif /* !NO_AES && HAVE_AESGCM */

--- a/tests/aes_keywrap_pad_test.c
+++ b/tests/aes_keywrap_pad_test.c
@@ -468,6 +468,11 @@ static int test_unwrap_rejects(CK_SESSION_HANDLE session)
     CHECK_CKR(ret, "Reject: too-short ciphertext",
               CKR_ENCRYPTED_DATA_LEN_RANGE);
 
+    /* Empty input cannot be wrapped (RFC 5649 requires at least one octet). */
+    wrappedLen = sizeof(wrapped);
+    ret = kwp_wrap(session, kek, rfc5649_pt1, 0, wrapped, &wrappedLen);
+    CHECK_CKR(ret, "Reject: empty input wrap", CKR_DATA_LEN_RANGE);
+
 cleanup:
     if (kek != CK_INVALID_HANDLE)
         funcList->C_DestroyObject(session, kek);

--- a/tests/aes_keywrap_pad_test.c
+++ b/tests/aes_keywrap_pad_test.c
@@ -1,0 +1,507 @@
+/* aes_keywrap_pad_test.c
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfPKCS11.
+ *
+ * wolfPKCS11 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfPKCS11 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ *
+ * Test for CKM_AES_KEY_WRAP_PAD RFC 5649 conformance (bug #6060).
+ *
+ * The buggy implementation layered PKCS#7 padding over RFC 3394: it over-padded
+ * block-aligned inputs by a whole block, used a length-encoding scheme that does
+ * not match RFC 5649, and could not wrap 1-7 byte inputs at all. This test pins
+ * the RFC 5649 6 test vectors and checks the wrap/unwrap roundtrip and output
+ * length for inputs 1..40 bytes.
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
+#include <stdio.h>
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/misc.h>
+
+#ifndef WOLFPKCS11_USER_SETTINGS
+    #include <wolfpkcs11/options.h>
+#endif
+#include <wolfpkcs11/pkcs11.h>
+
+#ifndef HAVE_PKCS11_STATIC
+#include <dlfcn.h>
+#endif
+
+#include "testdata.h"
+
+#if !defined(NO_AES) && defined(HAVE_AES_KEYWRAP)
+
+#define KWP_TEST_DIR "./store/aes_keywrap_pad_test"
+#define WOLFPKCS11_TOKEN_FILENAME "wp11_token_0000000000000001"
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+#define CHECK_CKR(rv, op, expected) do {                    \
+    if (rv != expected) {                                   \
+        fprintf(stderr, "FAIL: %s: expected %ld, got %ld\n", op, (long)expected, (long)rv); \
+        test_failed++;                                      \
+        result = -1;                                        \
+        goto cleanup;                                       \
+    } else {                                                \
+        printf("PASS: %s\n", op);                           \
+        test_passed++;                                      \
+    }                                                       \
+} while(0)
+
+#define CHECK_COND(cond, op) do {                           \
+    if (!(cond)) {                                          \
+        fprintf(stderr, "FAIL: %s\n", op);                 \
+        test_failed++;                                      \
+        result = -1;                                        \
+        goto cleanup;                                       \
+    } else {                                                \
+        printf("PASS: %s\n", op);                           \
+        test_passed++;                                      \
+    }                                                       \
+} while(0)
+
+#ifndef HAVE_PKCS11_STATIC
+static void* dlib;
+#endif
+static CK_FUNCTION_LIST* funcList;
+static CK_SLOT_ID slot = 0;
+static const char* tokenName = "wolfpkcs11";
+static byte* soPin = (byte*)"password123456";
+static int soPinLen = 14;
+static byte* userPin = (byte*)"someUserPin";
+static int userPinLen = 11;
+
+static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
+static CK_BBOOL ckTrue = CK_TRUE;
+static CK_KEY_TYPE aesKeyType = CKK_AES;
+
+/* RFC 5649 6 KEK (AES-192). */
+static const byte rfc5649_kek[24] = {
+    0x58,0x40,0xdf,0x6e,0x29,0xb0,0x2a,0xf1,
+    0xab,0x49,0x3b,0x70,0x5b,0xf1,0x6e,0xa1,
+    0xae,0x83,0x38,0xf4,0xdc,0xc1,0x76,0xa8
+};
+/* Test vector 1: 20-byte plaintext -> 32-byte wrap. */
+static const byte rfc5649_pt1[20] = {
+    0xc3,0x7b,0x7e,0x64,0x92,0x58,0x43,0x40,
+    0xbe,0xd1,0x22,0x07,0x80,0x89,0x41,0x15,
+    0x50,0x68,0xf7,0x38
+};
+static const byte rfc5649_ct1[32] = {
+    0x13,0x8b,0xde,0xaa,0x9b,0x8f,0xa7,0xfc,
+    0x61,0xf9,0x77,0x42,0xe7,0x22,0x48,0xee,
+    0x5a,0xe6,0xae,0x53,0x60,0xd1,0xae,0x6a,
+    0x5f,0x54,0xf3,0x73,0xfa,0x54,0x3b,0x6a
+};
+/* Test vector 2: 7-byte plaintext -> 16-byte wrap (single semiblock). */
+static const byte rfc5649_pt2[7] = {
+    0x46,0x6f,0x72,0x50,0x61,0x73,0x69
+};
+static const byte rfc5649_ct2[16] = {
+    0xaf,0xbe,0xb0,0xf0,0x7d,0xfb,0xf5,0x41,
+    0x92,0x00,0xf2,0xcc,0xb5,0x0b,0xb2,0x4f
+};
+
+static CK_RV pkcs11_init(void)
+{
+    CK_RV ret;
+    CK_C_INITIALIZE_ARGS args;
+    CK_SLOT_ID slotList[16];
+    CK_ULONG slotCount = sizeof(slotList) / sizeof(slotList[0]);
+
+#ifndef HAVE_PKCS11_STATIC
+    CK_C_GetFunctionList func;
+
+    dlib = dlopen(WOLFPKCS11_DLL_FILENAME, RTLD_NOW | RTLD_LOCAL);
+    if (dlib == NULL) {
+        fprintf(stderr, "dlopen error: %s\n", dlerror());
+        return -1;
+    }
+    func = (CK_C_GetFunctionList)dlsym(dlib, "C_GetFunctionList");
+    if (func == NULL) {
+        fprintf(stderr, "Failed to get function list function\n");
+        dlclose(dlib);
+        return -1;
+    }
+    ret = func(&funcList);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "Failed to get function list: 0x%lx\n",
+            (unsigned long)ret);
+        dlclose(dlib);
+        return ret;
+    }
+#else
+    ret = C_GetFunctionList(&funcList);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "Failed to get function list: 0x%lx\n",
+            (unsigned long)ret);
+        return ret;
+    }
+#endif
+
+    XMEMSET(&args, 0, sizeof(args));
+    args.flags = CKF_OS_LOCKING_OK;
+    ret = funcList->C_Initialize(&args);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_GetSlotList(CK_TRUE, slotList, &slotCount);
+    if (ret != CKR_OK)
+        return ret;
+
+    if (slotCount > 0)
+        slot = slotList[0];
+    else {
+        fprintf(stderr, "No slots available\n");
+        return CKR_GENERAL_ERROR;
+    }
+
+    return ret;
+}
+
+static CK_RV pkcs11_final(void)
+{
+    if (funcList != NULL) {
+        funcList->C_Finalize(NULL);
+        funcList = NULL;
+    }
+#ifndef HAVE_PKCS11_STATIC
+    if (dlib) {
+        dlclose(dlib);
+        dlib = NULL;
+    }
+#endif
+    return CKR_OK;
+}
+
+static CK_RV pkcs11_init_token(void)
+{
+    unsigned char label[32];
+
+    XMEMSET(label, ' ', sizeof(label));
+    XMEMCPY(label, tokenName, XSTRLEN(tokenName));
+    return funcList->C_InitToken(slot, soPin, soPinLen, label);
+}
+
+static CK_RV pkcs11_set_user_pin(void)
+{
+    CK_SESSION_HANDLE soSession;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+    CK_RV ret;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, &soSession);
+    if (ret != CKR_OK)
+        return ret;
+    ret = funcList->C_Login(soSession, CKU_SO, soPin, soPinLen);
+    if (ret != CKR_OK) {
+        funcList->C_CloseSession(soSession);
+        return ret;
+    }
+    ret = funcList->C_InitPIN(soSession, userPin, userPinLen);
+    funcList->C_Logout(soSession);
+    funcList->C_CloseSession(soSession);
+    return ret;
+}
+
+static CK_RV pkcs11_open_session(CK_SESSION_HANDLE* session)
+{
+    CK_RV ret;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, session);
+    if (ret != CKR_OK)
+        return ret;
+    ret = funcList->C_Login(*session, CKU_USER, userPin, userPinLen);
+    if (ret != CKR_OK) {
+        funcList->C_CloseSession(*session);
+        return ret;
+    }
+    return CKR_OK;
+}
+
+static CK_RV pkcs11_close_session(CK_SESSION_HANDLE session)
+{
+    funcList->C_Logout(session);
+    return funcList->C_CloseSession(session);
+}
+
+static void cleanup_test_files(const char* dir)
+{
+    char filepath[512];
+
+    snprintf(filepath, sizeof(filepath), "%s" PATH_SEP "%s", dir,
+             WOLFPKCS11_TOKEN_FILENAME);
+    (void)remove(filepath);
+}
+
+static CK_RV create_kek(CK_SESSION_HANDLE session, const byte* keyVal,
+                        CK_ULONG keyLen, CK_OBJECT_HANDLE* key)
+{
+    CK_ATTRIBUTE tmpl[] = {
+        { CKA_CLASS,    &secretKeyClass, sizeof(secretKeyClass) },
+        { CKA_KEY_TYPE, &aesKeyType,     sizeof(aesKeyType)     },
+        { CKA_ENCRYPT,  &ckTrue,         sizeof(ckTrue)         },
+        { CKA_DECRYPT,  &ckTrue,         sizeof(ckTrue)         },
+        { CKA_WRAP,     &ckTrue,         sizeof(ckTrue)         },
+        { CKA_UNWRAP,   &ckTrue,         sizeof(ckTrue)         },
+        { CKA_VALUE,    (CK_BYTE*)keyVal, keyLen                },
+        { CKA_TOKEN,    &ckTrue,         sizeof(ckTrue)         },
+    };
+    CK_ULONG tmplCnt = sizeof(tmpl) / sizeof(*tmpl);
+
+    return funcList->C_CreateObject(session, tmpl, tmplCnt, key);
+}
+
+static CK_RV kwp_wrap(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE kek,
+                      const byte* in, CK_ULONG inLen, byte* out,
+                      CK_ULONG* outLen)
+{
+    CK_MECHANISM mech;
+    CK_RV ret;
+
+    mech.mechanism = CKM_AES_KEY_WRAP_PAD;
+    mech.pParameter = NULL;
+    mech.ulParameterLen = 0;
+
+    ret = funcList->C_EncryptInit(session, &mech, kek);
+    if (ret != CKR_OK)
+        return ret;
+    return funcList->C_Encrypt(session, (CK_BYTE*)in, inLen, out, outLen);
+}
+
+static CK_RV kwp_unwrap(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE kek,
+                        const byte* in, CK_ULONG inLen, byte* out,
+                        CK_ULONG* outLen)
+{
+    CK_MECHANISM mech;
+    CK_RV ret;
+
+    mech.mechanism = CKM_AES_KEY_WRAP_PAD;
+    mech.pParameter = NULL;
+    mech.ulParameterLen = 0;
+
+    ret = funcList->C_DecryptInit(session, &mech, kek);
+    if (ret != CKR_OK)
+        return ret;
+    return funcList->C_Decrypt(session, (CK_BYTE*)in, inLen, out, outLen);
+}
+
+/* Pin the two RFC 5649 6 test vectors (interoperability). */
+static int test_rfc_vectors(CK_SESSION_HANDLE session)
+{
+    CK_RV ret;
+    CK_OBJECT_HANDLE kek = CK_INVALID_HANDLE;
+    byte wrapped[64];
+    byte unwrapped[64];
+    CK_ULONG wrappedLen, unwrappedLen;
+    int result = 0;
+
+    ret = create_kek(session, rfc5649_kek, sizeof(rfc5649_kek), &kek);
+    CHECK_CKR(ret, "RFC: create AES-192 KEK", CKR_OK);
+
+    /* Vector 1: 20 bytes -> 32 bytes */
+    wrappedLen = sizeof(wrapped);
+    ret = kwp_wrap(session, kek, rfc5649_pt1, sizeof(rfc5649_pt1), wrapped,
+                   &wrappedLen);
+    CHECK_CKR(ret, "RFC1: wrap", CKR_OK);
+    CHECK_COND(wrappedLen == sizeof(rfc5649_ct1) &&
+               XMEMCMP(wrapped, rfc5649_ct1, sizeof(rfc5649_ct1)) == 0,
+               "RFC1: wrap matches published vector");
+
+    unwrappedLen = sizeof(unwrapped);
+    ret = kwp_unwrap(session, kek, rfc5649_ct1, sizeof(rfc5649_ct1), unwrapped,
+                     &unwrappedLen);
+    CHECK_CKR(ret, "RFC1: unwrap", CKR_OK);
+    CHECK_COND(unwrappedLen == sizeof(rfc5649_pt1) &&
+               XMEMCMP(unwrapped, rfc5649_pt1, sizeof(rfc5649_pt1)) == 0,
+               "RFC1: unwrap recovers plaintext");
+
+    /* Vector 2: 7 bytes -> 16 bytes (single semiblock) */
+    wrappedLen = sizeof(wrapped);
+    ret = kwp_wrap(session, kek, rfc5649_pt2, sizeof(rfc5649_pt2), wrapped,
+                   &wrappedLen);
+    CHECK_CKR(ret, "RFC2: wrap", CKR_OK);
+    CHECK_COND(wrappedLen == sizeof(rfc5649_ct2) &&
+               XMEMCMP(wrapped, rfc5649_ct2, sizeof(rfc5649_ct2)) == 0,
+               "RFC2: wrap matches published vector");
+
+    unwrappedLen = sizeof(unwrapped);
+    ret = kwp_unwrap(session, kek, rfc5649_ct2, sizeof(rfc5649_ct2), unwrapped,
+                     &unwrappedLen);
+    CHECK_CKR(ret, "RFC2: unwrap", CKR_OK);
+    CHECK_COND(unwrappedLen == sizeof(rfc5649_pt2) &&
+               XMEMCMP(unwrapped, rfc5649_pt2, sizeof(rfc5649_pt2)) == 0,
+               "RFC2: unwrap recovers plaintext");
+
+cleanup:
+    if (kek != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, kek);
+    return result;
+}
+
+/* Wrap/unwrap roundtrip for every length 1..40, checking the wrapped length is
+ * roundup8(len)+8 and the recovered plaintext matches. */
+static int test_roundtrip_lengths(CK_SESSION_HANDLE session)
+{
+    CK_RV ret;
+    CK_OBJECT_HANDLE kek = CK_INVALID_HANDLE;
+    byte plain[40];
+    byte wrapped[64];
+    byte unwrapped[64];
+    CK_ULONG len;
+    int result = 0;
+    char msg[96];
+
+    for (len = 0; len < sizeof(plain); len++)
+        plain[len] = (byte)(0x10 + len);
+
+    ret = create_kek(session, rfc5649_kek, sizeof(rfc5649_kek), &kek);
+    CHECK_CKR(ret, "Roundtrip: create AES-192 KEK", CKR_OK);
+
+    for (len = 1; len <= sizeof(plain); len++) {
+        CK_ULONG wrappedLen = sizeof(wrapped);
+        CK_ULONG unwrappedLen = sizeof(unwrapped);
+        CK_ULONG expWrapped = ((len + 7) & ~(CK_ULONG)7) + 8;
+
+        ret = kwp_wrap(session, kek, plain, len, wrapped, &wrappedLen);
+        snprintf(msg, sizeof(msg), "Roundtrip len=%lu: wrap",
+                 (unsigned long)len);
+        CHECK_CKR(ret, msg, CKR_OK);
+
+        snprintf(msg, sizeof(msg),
+                 "Roundtrip len=%lu: wrapped length is roundup8(len)+8",
+                 (unsigned long)len);
+        CHECK_COND(wrappedLen == expWrapped, msg);
+
+        ret = kwp_unwrap(session, kek, wrapped, wrappedLen, unwrapped,
+                         &unwrappedLen);
+        snprintf(msg, sizeof(msg), "Roundtrip len=%lu: unwrap",
+                 (unsigned long)len);
+        CHECK_CKR(ret, msg, CKR_OK);
+
+        snprintf(msg, sizeof(msg),
+                 "Roundtrip len=%lu: recovered plaintext matches",
+                 (unsigned long)len);
+        CHECK_COND(unwrappedLen == len &&
+                   XMEMCMP(unwrapped, plain, len) == 0, msg);
+    }
+
+cleanup:
+    if (kek != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, kek);
+    return result;
+}
+
+static int aes_keywrap_pad_test(void)
+{
+    CK_RV ret;
+    CK_SESSION_HANDLE session = 0;
+    int result = 0;
+
+    printf("\n=== Testing CKM_AES_KEY_WRAP_PAD (RFC 5649) ===\n");
+
+    cleanup_test_files(KWP_TEST_DIR);
+
+    ret = pkcs11_init();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: pkcs11_init: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        return -1;
+    }
+    ret = pkcs11_init_token();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: C_InitToken: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+    ret = pkcs11_set_user_pin();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: set user PIN: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+    ret = pkcs11_open_session(&session);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: pkcs11_open_session: 0x%lx\n",
+                (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+
+    if (test_rfc_vectors(session) != 0)
+        result = -1;
+    if (test_roundtrip_lengths(session) != 0)
+        result = -1;
+
+    pkcs11_close_session(session);
+    pkcs11_final();
+    return result;
+}
+
+static void print_results(void)
+{
+    printf("\n=== Test Results ===\n");
+    printf("Tests passed: %d\n", test_passed);
+    printf("Tests failed: %d\n", test_failed);
+
+    if (test_failed == 0)
+        printf("ALL TESTS PASSED!\n");
+    else
+        printf("SOME TESTS FAILED!\n");
+}
+
+int main(int argc, char* argv[])
+{
+#ifndef WOLFPKCS11_NO_ENV
+    XSETENV("WOLFPKCS11_TOKEN_PATH", KWP_TEST_DIR, 1);
+#endif
+
+    (void)argc;
+    (void)argv;
+
+    printf("=== wolfPKCS11 AES-KEY-WRAP-PAD RFC 5649 Test ===\n");
+
+    (void)aes_keywrap_pad_test();
+
+    print_results();
+
+    return (test_failed == 0) ? 0 : 1;
+}
+
+#else /* NO_AES || !HAVE_AES_KEYWRAP */
+
+int main(int argc, char* argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("AES key wrap not available, skipping RFC 5649 test\n");
+    return 0;
+}
+
+#endif /* !NO_AES && HAVE_AES_KEYWRAP */

--- a/tests/aes_keywrap_pad_test.c
+++ b/tests/aes_keywrap_pad_test.c
@@ -90,8 +90,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
 static CK_BBOOL ckTrue = CK_TRUE;

--- a/tests/aes_keywrap_pad_test.c
+++ b/tests/aes_keywrap_pad_test.c
@@ -479,6 +479,51 @@ cleanup:
     return result;
 }
 
+/* Buffer-size handling: the recovered plaintext is shorter than the
+ * ciphertext - 8 upper bound, so a buffer smaller than the recovered length
+ * must be rejected with CKR_BUFFER_TOO_SMALL and the exact required length
+ * reported, while a buffer at least the recovered length (but below the upper
+ * bound) must succeed. */
+static int test_unwrap_buffer_size(CK_SESSION_HANDLE session)
+{
+    CK_RV ret;
+    CK_OBJECT_HANDLE kek = CK_INVALID_HANDLE;
+    byte wrapped[64];
+    byte out[64];
+    CK_ULONG wrappedLen, outLen;
+    int result = 0;
+
+    ret = create_kek(session, rfc5649_kek, sizeof(rfc5649_kek), &kek);
+    CHECK_CKR(ret, "Bufsize: create AES-192 KEK", CKR_OK);
+
+    /* 20-byte plaintext wraps to 32 bytes: upper bound 24, exact length 20. */
+    wrappedLen = sizeof(wrapped);
+    ret = kwp_wrap(session, kek, rfc5649_pt1, sizeof(rfc5649_pt1), wrapped,
+                   &wrappedLen);
+    CHECK_CKR(ret, "Bufsize: wrap", CKR_OK);
+    CHECK_COND(wrappedLen == sizeof(rfc5649_ct1), "Bufsize: wrapped length");
+
+    /* Buffer smaller than the recovered plaintext: reject and report size. */
+    outLen = sizeof(rfc5649_pt1) - 4;
+    ret = kwp_unwrap(session, kek, wrapped, wrappedLen, out, &outLen);
+    CHECK_CKR(ret, "Bufsize: too-small buffer", CKR_BUFFER_TOO_SMALL);
+    CHECK_COND(outLen == sizeof(rfc5649_pt1),
+               "Bufsize: required length reported");
+
+    /* Buffer equal to the recovered length but below the upper bound: succeed. */
+    outLen = sizeof(rfc5649_pt1);
+    ret = kwp_unwrap(session, kek, wrapped, wrappedLen, out, &outLen);
+    CHECK_CKR(ret, "Bufsize: exact-size buffer", CKR_OK);
+    CHECK_COND(outLen == sizeof(rfc5649_pt1) &&
+               XMEMCMP(out, rfc5649_pt1, sizeof(rfc5649_pt1)) == 0,
+               "Bufsize: exact-size buffer recovers plaintext");
+
+cleanup:
+    if (kek != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, kek);
+    return result;
+}
+
 static int aes_keywrap_pad_test(void)
 {
     CK_RV ret;
@@ -523,6 +568,8 @@ static int aes_keywrap_pad_test(void)
     if (test_roundtrip_lengths(session) != 0)
         result = -1;
     if (test_unwrap_rejects(session) != 0)
+        result = -1;
+    if (test_unwrap_buffer_size(session) != 0)
         result = -1;
 
     pkcs11_close_session(session);

--- a/tests/aes_keywrap_pad_test.c
+++ b/tests/aes_keywrap_pad_test.c
@@ -414,6 +414,66 @@ cleanup:
     return result;
 }
 
+/*
+ * Corrupted or wrong-length wrapped blobs must be rejected, exercising the
+ * AIV/length validation paths in the unwrap (single-semiblock and multi-block).
+ */
+static int test_unwrap_rejects(CK_SESSION_HANDLE session)
+{
+    CK_RV ret;
+    CK_OBJECT_HANDLE kek = CK_INVALID_HANDLE;
+    byte wrapped[64];
+    byte out[64];
+    CK_ULONG wrappedLen, outLen;
+    int result = 0;
+
+    ret = create_kek(session, rfc5649_kek, sizeof(rfc5649_kek), &kek);
+    CHECK_CKR(ret, "Reject: create AES-192 KEK", CKR_OK);
+
+    /* Multi-block blob: tampering a byte must fail the AIV/integrity check. */
+    wrappedLen = sizeof(wrapped);
+    ret = kwp_wrap(session, kek, rfc5649_pt1, sizeof(rfc5649_pt1), wrapped,
+                   &wrappedLen);
+    CHECK_CKR(ret, "Reject: wrap multi-block", CKR_OK);
+    wrapped[0] ^= 0x80;
+    outLen = sizeof(out);
+    ret = kwp_unwrap(session, kek, wrapped, wrappedLen, out, &outLen);
+    CHECK_CKR(ret, "Reject: tampered multi-block unwrap",
+              CKR_ENCRYPTED_DATA_INVALID);
+
+    /* Single-semiblock blob: tampering a byte must fail. */
+    wrappedLen = sizeof(wrapped);
+    ret = kwp_wrap(session, kek, rfc5649_pt2, sizeof(rfc5649_pt2), wrapped,
+                   &wrappedLen);
+    CHECK_CKR(ret, "Reject: wrap single-block", CKR_OK);
+    wrapped[wrappedLen - 1] ^= 0x01;
+    outLen = sizeof(out);
+    ret = kwp_unwrap(session, kek, wrapped, wrappedLen, out, &outLen);
+    CHECK_CKR(ret, "Reject: tampered single-block unwrap",
+              CKR_ENCRYPTED_DATA_INVALID);
+
+    /* Ciphertext length not a multiple of 8 must be rejected. */
+    wrappedLen = sizeof(wrapped);
+    ret = kwp_wrap(session, kek, rfc5649_pt1, sizeof(rfc5649_pt1), wrapped,
+                   &wrappedLen);
+    CHECK_CKR(ret, "Reject: wrap for length checks", CKR_OK);
+    outLen = sizeof(out);
+    ret = kwp_unwrap(session, kek, wrapped, wrappedLen - 1, out, &outLen);
+    CHECK_CKR(ret, "Reject: non-block-aligned ciphertext",
+              CKR_ENCRYPTED_DATA_LEN_RANGE);
+
+    /* Ciphertext shorter than two semiblocks must be rejected. */
+    outLen = sizeof(out);
+    ret = kwp_unwrap(session, kek, wrapped, 8, out, &outLen);
+    CHECK_CKR(ret, "Reject: too-short ciphertext",
+              CKR_ENCRYPTED_DATA_LEN_RANGE);
+
+cleanup:
+    if (kek != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, kek);
+    return result;
+}
+
 static int aes_keywrap_pad_test(void)
 {
     CK_RV ret;
@@ -456,6 +516,8 @@ static int aes_keywrap_pad_test(void)
     if (test_rfc_vectors(session) != 0)
         result = -1;
     if (test_roundtrip_lengths(session) != 0)
+        result = -1;
+    if (test_unwrap_rejects(session) != 0)
         result = -1;
 
     pkcs11_close_session(session);

--- a/tests/copyobject_token_test.c
+++ b/tests/copyobject_token_test.c
@@ -1,0 +1,550 @@
+/* copyobject_token_test.c
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfPKCS11.
+ *
+ * wolfPKCS11 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfPKCS11 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ *
+ * Test for C_CopyObject CKA_TOKEN inheritance (bug #4534).
+ *
+ * Per PKCS#11 v2.40 4.6.2, a copy's attributes equal the source's except where
+ * the supplied template overrides them. CKA_TOKEN must therefore default to the
+ * source object's CKA_TOKEN when the template omits it. The buggy code defaulted
+ * the copy to a session object regardless of the source.
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
+#include <stdio.h>
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/misc.h>
+
+#ifndef WOLFPKCS11_USER_SETTINGS
+    #include <wolfpkcs11/options.h>
+#endif
+#include <wolfpkcs11/pkcs11.h>
+
+#ifndef HAVE_PKCS11_STATIC
+#include <dlfcn.h>
+#endif
+
+#include "testdata.h"
+
+#if !defined(NO_AES)
+
+#define COPY_TOKEN_TEST_DIR "./store/copyobject_token_test"
+#define WOLFPKCS11_TOKEN_FILENAME "wp11_token_0000000000000001"
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+#define CHECK_CKR(rv, op, expected) do {                    \
+    if (rv != expected) {                                   \
+        fprintf(stderr, "FAIL: %s: expected %ld, got %ld\n", op, (long)expected, (long)rv); \
+        test_failed++;                                      \
+        result = -1;                                        \
+        goto cleanup;                                       \
+    } else {                                                \
+        printf("PASS: %s\n", op);                           \
+        test_passed++;                                      \
+    }                                                       \
+} while(0)
+
+#define CHECK_COND(cond, op) do {                           \
+    if (!(cond)) {                                          \
+        fprintf(stderr, "FAIL: %s\n", op);                 \
+        test_failed++;                                      \
+        result = -1;                                        \
+        goto cleanup;                                       \
+    } else {                                                \
+        printf("PASS: %s\n", op);                           \
+        test_passed++;                                      \
+    }                                                       \
+} while(0)
+
+#ifndef HAVE_PKCS11_STATIC
+static void* dlib;
+#endif
+static CK_FUNCTION_LIST* funcList;
+static CK_SLOT_ID slot = 0;
+static const char* tokenName = "wolfpkcs11";
+static byte* soPin = (byte*)"password123456";
+static int soPinLen = 14;
+static byte* userPin = (byte*)"someUserPin";
+static int userPinLen = 11;
+
+static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
+static CK_BBOOL ckTrue = CK_TRUE;
+static CK_BBOOL ckFalse = CK_FALSE;
+static CK_KEY_TYPE aesKeyType = CKK_AES;
+
+static CK_RV pkcs11_init(void)
+{
+    CK_RV ret;
+    CK_C_INITIALIZE_ARGS args;
+    CK_SLOT_ID slotList[16];
+    CK_ULONG slotCount = sizeof(slotList) / sizeof(slotList[0]);
+
+#ifndef HAVE_PKCS11_STATIC
+    CK_C_GetFunctionList func;
+
+    dlib = dlopen(WOLFPKCS11_DLL_FILENAME, RTLD_NOW | RTLD_LOCAL);
+    if (dlib == NULL) {
+        fprintf(stderr, "dlopen error: %s\n", dlerror());
+        return -1;
+    }
+
+    func = (CK_C_GetFunctionList)dlsym(dlib, "C_GetFunctionList");
+    if (func == NULL) {
+        fprintf(stderr, "Failed to get function list function\n");
+        dlclose(dlib);
+        return -1;
+    }
+
+    ret = func(&funcList);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "Failed to get function list: 0x%lx\n",
+            (unsigned long)ret);
+        dlclose(dlib);
+        return ret;
+    }
+#else
+    ret = C_GetFunctionList(&funcList);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "Failed to get function list: 0x%lx\n",
+            (unsigned long)ret);
+        return ret;
+    }
+#endif
+
+    XMEMSET(&args, 0, sizeof(args));
+    args.flags = CKF_OS_LOCKING_OK;
+    ret = funcList->C_Initialize(&args);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_GetSlotList(CK_TRUE, slotList, &slotCount);
+    if (ret != CKR_OK)
+        return ret;
+
+    if (slotCount > 0) {
+        slot = slotList[0];
+    } else {
+        fprintf(stderr, "No slots available\n");
+        return CKR_GENERAL_ERROR;
+    }
+
+    return ret;
+}
+
+static CK_RV pkcs11_final(void)
+{
+    if (funcList != NULL) {
+        funcList->C_Finalize(NULL);
+        funcList = NULL;
+    }
+#ifndef HAVE_PKCS11_STATIC
+    if (dlib) {
+        dlclose(dlib);
+        dlib = NULL;
+    }
+#endif
+    return CKR_OK;
+}
+
+static CK_RV pkcs11_init_token(void)
+{
+    unsigned char label[32];
+
+    XMEMSET(label, ' ', sizeof(label));
+    XMEMCPY(label, tokenName, XSTRLEN(tokenName));
+
+    return funcList->C_InitToken(slot, soPin, soPinLen, label);
+}
+
+static CK_RV pkcs11_set_user_pin(void)
+{
+    CK_SESSION_HANDLE soSession;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+    CK_RV ret;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, &soSession);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_Login(soSession, CKU_SO, soPin, soPinLen);
+    if (ret != CKR_OK) {
+        funcList->C_CloseSession(soSession);
+        return ret;
+    }
+
+    ret = funcList->C_InitPIN(soSession, userPin, userPinLen);
+    funcList->C_Logout(soSession);
+    funcList->C_CloseSession(soSession);
+    return ret;
+}
+
+static CK_RV pkcs11_open_session(CK_SESSION_HANDLE* session)
+{
+    CK_RV ret;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, session);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_Login(*session, CKU_USER, userPin, userPinLen);
+    if (ret != CKR_OK) {
+        funcList->C_CloseSession(*session);
+        return ret;
+    }
+
+    return CKR_OK;
+}
+
+static CK_RV pkcs11_close_session(CK_SESSION_HANDLE session)
+{
+    funcList->C_Logout(session);
+    return funcList->C_CloseSession(session);
+}
+
+static void cleanup_test_files(const char* dir)
+{
+    char filepath[512];
+
+    snprintf(filepath, sizeof(filepath), "%s" PATH_SEP "%s", dir,
+             WOLFPKCS11_TOKEN_FILENAME);
+    (void)remove(filepath);
+}
+
+/* Create an AES secret key with the requested CKA_TOKEN value. */
+static CK_RV create_aes_key(CK_SESSION_HANDLE session, CK_BBOOL onToken,
+                            CK_OBJECT_HANDLE* key)
+{
+    CK_ATTRIBUTE tmpl[] = {
+        { CKA_CLASS,       &secretKeyClass,   sizeof(secretKeyClass)   },
+        { CKA_KEY_TYPE,    &aesKeyType,       sizeof(aesKeyType)       },
+        { CKA_ENCRYPT,     &ckTrue,           sizeof(ckTrue)           },
+        { CKA_DECRYPT,     &ckTrue,           sizeof(ckTrue)           },
+        { CKA_VALUE,       aes_128_key,       sizeof(aes_128_key)      },
+        { CKA_TOKEN,       &onToken,          sizeof(onToken)          },
+    };
+    CK_ULONG tmplCnt = sizeof(tmpl) / sizeof(*tmpl);
+
+    return funcList->C_CreateObject(session, tmpl, tmplCnt, key);
+}
+
+/* Read CKA_TOKEN of an object. */
+static CK_RV get_token_attr(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE obj,
+                            CK_BBOOL* onToken)
+{
+    CK_ATTRIBUTE tmpl[] = {
+        { CKA_TOKEN, onToken, sizeof(*onToken) },
+    };
+
+    *onToken = 0xAA; /* sentinel so an untouched value is detectable */
+    return funcList->C_GetAttributeValue(session, obj, tmpl, 1);
+}
+
+/*
+ * Test 1: Copy a token object with an empty template. The copy must inherit
+ * CKA_TOKEN=TRUE from the source. This is the reported bug.
+ */
+static int test_copy_token_inherits_true(CK_SESSION_HANDLE session)
+{
+    CK_RV ret;
+    CK_OBJECT_HANDLE src = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE copy = CK_INVALID_HANDLE;
+    CK_BBOOL onToken = 0;
+    int result = 0;
+
+    ret = create_aes_key(session, CK_TRUE, &src);
+    CHECK_CKR(ret, "Test1: create token source object", CKR_OK);
+
+    ret = funcList->C_CopyObject(session, src, NULL, 0, &copy);
+    CHECK_CKR(ret, "Test1: C_CopyObject empty template", CKR_OK);
+
+    ret = get_token_attr(session, copy, &onToken);
+    CHECK_CKR(ret, "Test1: C_GetAttributeValue CKA_TOKEN", CKR_OK);
+
+    CHECK_COND(onToken == CK_TRUE,
+               "Test1: copy of token object inherits CKA_TOKEN=TRUE");
+
+cleanup:
+    if (copy != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, copy);
+    if (src != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, src);
+    return result;
+}
+
+/*
+ * Test 2: Copy a token object but override CKA_TOKEN=FALSE in the template.
+ * The copy must be a session object.
+ */
+static int test_copy_token_override_false(CK_SESSION_HANDLE session)
+{
+    CK_RV ret;
+    CK_OBJECT_HANDLE src = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE copy = CK_INVALID_HANDLE;
+    CK_BBOOL onToken = 0;
+    int result = 0;
+    CK_ATTRIBUTE tmpl[] = {
+        { CKA_TOKEN, &ckFalse, sizeof(ckFalse) },
+    };
+
+    ret = create_aes_key(session, CK_TRUE, &src);
+    CHECK_CKR(ret, "Test2: create token source object", CKR_OK);
+
+    ret = funcList->C_CopyObject(session, src, tmpl, 1, &copy);
+    CHECK_CKR(ret, "Test2: C_CopyObject CKA_TOKEN=FALSE", CKR_OK);
+
+    ret = get_token_attr(session, copy, &onToken);
+    CHECK_CKR(ret, "Test2: C_GetAttributeValue CKA_TOKEN", CKR_OK);
+
+    CHECK_COND(onToken == CK_FALSE,
+               "Test2: template override CKA_TOKEN=FALSE honored");
+
+cleanup:
+    if (copy != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, copy);
+    if (src != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, src);
+    return result;
+}
+
+/*
+ * Test 3: Copy a session object with an empty template. The copy must remain a
+ * session object (inherit CKA_TOKEN=FALSE).
+ */
+static int test_copy_session_inherits_false(CK_SESSION_HANDLE session)
+{
+    CK_RV ret;
+    CK_OBJECT_HANDLE src = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE copy = CK_INVALID_HANDLE;
+    CK_BBOOL onToken = 0;
+    int result = 0;
+
+    ret = create_aes_key(session, CK_FALSE, &src);
+    CHECK_CKR(ret, "Test3: create session source object", CKR_OK);
+
+    ret = funcList->C_CopyObject(session, src, NULL, 0, &copy);
+    CHECK_CKR(ret, "Test3: C_CopyObject empty template", CKR_OK);
+
+    ret = get_token_attr(session, copy, &onToken);
+    CHECK_CKR(ret, "Test3: C_GetAttributeValue CKA_TOKEN", CKR_OK);
+
+    CHECK_COND(onToken == CK_FALSE,
+               "Test3: copy of session object inherits CKA_TOKEN=FALSE");
+
+cleanup:
+    if (copy != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, copy);
+    if (src != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, src);
+    return result;
+}
+
+/*
+ * Test 4: Copy a session object but override CKA_TOKEN=TRUE in the template.
+ * The copy must become a token object.
+ */
+static int test_copy_session_override_true(CK_SESSION_HANDLE session)
+{
+    CK_RV ret;
+    CK_OBJECT_HANDLE src = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE copy = CK_INVALID_HANDLE;
+    CK_BBOOL onToken = 0;
+    int result = 0;
+    CK_ATTRIBUTE tmpl[] = {
+        { CKA_TOKEN, &ckTrue, sizeof(ckTrue) },
+    };
+
+    ret = create_aes_key(session, CK_FALSE, &src);
+    CHECK_CKR(ret, "Test4: create session source object", CKR_OK);
+
+    ret = funcList->C_CopyObject(session, src, tmpl, 1, &copy);
+    CHECK_CKR(ret, "Test4: C_CopyObject CKA_TOKEN=TRUE", CKR_OK);
+
+    ret = get_token_attr(session, copy, &onToken);
+    CHECK_CKR(ret, "Test4: C_GetAttributeValue CKA_TOKEN", CKR_OK);
+
+    CHECK_COND(onToken == CK_TRUE,
+               "Test4: template override CKA_TOKEN=TRUE honored");
+
+cleanup:
+    if (copy != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, copy);
+    if (src != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, src);
+    return result;
+}
+
+/*
+ * Test 5: A token object copy (empty template) must be discoverable by a
+ * C_FindObjects search restricted to token objects.
+ */
+static int test_copy_token_findable(CK_SESSION_HANDLE session)
+{
+    CK_RV ret;
+    CK_OBJECT_HANDLE src = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE copy = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE found[8];
+    CK_ULONG foundCount = 0;
+    CK_ULONG i;
+    int sawCopy = 0;
+    int result = 0;
+    CK_ATTRIBUTE findTmpl[] = {
+        { CKA_TOKEN, &ckTrue, sizeof(ckTrue) },
+    };
+
+    ret = create_aes_key(session, CK_TRUE, &src);
+    CHECK_CKR(ret, "Test5: create token source object", CKR_OK);
+
+    ret = funcList->C_CopyObject(session, src, NULL, 0, &copy);
+    CHECK_CKR(ret, "Test5: C_CopyObject empty template", CKR_OK);
+
+    ret = funcList->C_FindObjectsInit(session, findTmpl, 1);
+    CHECK_CKR(ret, "Test5: C_FindObjectsInit token filter", CKR_OK);
+
+    ret = funcList->C_FindObjects(session, found,
+                                  sizeof(found) / sizeof(found[0]), &foundCount);
+    CHECK_CKR(ret, "Test5: C_FindObjects", CKR_OK);
+
+    ret = funcList->C_FindObjectsFinal(session);
+    CHECK_CKR(ret, "Test5: C_FindObjectsFinal", CKR_OK);
+
+    for (i = 0; i < foundCount; i++) {
+        if (found[i] == copy)
+            sawCopy = 1;
+    }
+    CHECK_COND(sawCopy,
+               "Test5: token-object copy found via CKA_TOKEN=TRUE search");
+
+cleanup:
+    if (copy != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, copy);
+    if (src != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, src);
+    return result;
+}
+
+static int copyobject_token_test(void)
+{
+    CK_RV ret;
+    CK_SESSION_HANDLE session = 0;
+    int result = 0;
+
+    printf("\n=== Testing C_CopyObject CKA_TOKEN inheritance ===\n");
+
+    cleanup_test_files(COPY_TOKEN_TEST_DIR);
+
+    ret = pkcs11_init();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: pkcs11_init: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        return -1;
+    }
+
+    ret = pkcs11_init_token();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: C_InitToken: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+
+    ret = pkcs11_set_user_pin();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: set user PIN: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+
+    ret = pkcs11_open_session(&session);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: pkcs11_open_session: 0x%lx\n",
+                (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+
+    if (test_copy_token_inherits_true(session) != 0)
+        result = -1;
+    if (test_copy_token_override_false(session) != 0)
+        result = -1;
+    if (test_copy_session_inherits_false(session) != 0)
+        result = -1;
+    if (test_copy_session_override_true(session) != 0)
+        result = -1;
+    if (test_copy_token_findable(session) != 0)
+        result = -1;
+
+    pkcs11_close_session(session);
+    pkcs11_final();
+    return result;
+}
+
+static void print_results(void)
+{
+    printf("\n=== Test Results ===\n");
+    printf("Tests passed: %d\n", test_passed);
+    printf("Tests failed: %d\n", test_failed);
+
+    if (test_failed == 0)
+        printf("ALL TESTS PASSED!\n");
+    else
+        printf("SOME TESTS FAILED!\n");
+}
+
+int main(int argc, char* argv[])
+{
+#ifndef WOLFPKCS11_NO_ENV
+    XSETENV("WOLFPKCS11_TOKEN_PATH", COPY_TOKEN_TEST_DIR, 1);
+#endif
+
+    (void)argc;
+    (void)argv;
+
+    printf("=== wolfPKCS11 C_CopyObject CKA_TOKEN Test ===\n");
+
+    (void)copyobject_token_test();
+
+    print_results();
+
+    return (test_failed == 0) ? 0 : 1;
+}
+
+#else /* NO_AES */
+
+int main(int argc, char* argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("AES not available, skipping C_CopyObject CKA_TOKEN test\n");
+    return 0;
+}
+
+#endif /* !NO_AES */

--- a/tests/copyobject_token_test.c
+++ b/tests/copyobject_token_test.c
@@ -89,8 +89,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
 static CK_BBOOL ckTrue = CK_TRUE;

--- a/tests/include.am
+++ b/tests/include.am
@@ -230,6 +230,11 @@ noinst_PROGRAMS += tests/mlkem_secret_scrub_test
 tests_mlkem_secret_scrub_test_SOURCES = tests/mlkem_secret_scrub_test.c
 tests_mlkem_secret_scrub_test_LDADD =
 
+check_PROGRAMS += tests/logout_token_key_zero_test
+noinst_PROGRAMS += tests/logout_token_key_zero_test
+tests_logout_token_key_zero_test_SOURCES = tests/logout_token_key_zero_test.c
+tests_logout_token_key_zero_test_LDADD =
+
 if BUILD_STATIC
 tests_pkcs11test_LDADD += src/libwolfpkcs11.la
 tests_pkcs11mtt_LDADD  += src/libwolfpkcs11.la
@@ -277,6 +282,7 @@ tests_copyobject_token_test_LDADD += src/libwolfpkcs11.la
 tests_aes_gcm_multipart_test_LDADD += src/libwolfpkcs11.la
 tests_aes_keywrap_pad_test_LDADD += src/libwolfpkcs11.la
 tests_mlkem_secret_scrub_test_LDADD += src/libwolfpkcs11.la
+tests_logout_token_key_zero_test_LDADD += src/libwolfpkcs11.la
 else
 tests_object_id_uniqueness_test_LDADD += src/libwolfpkcs11.la
 tests_empty_pin_store_test_LDADD += src/libwolfpkcs11.la
@@ -316,6 +322,7 @@ tests_copyobject_token_test_LDADD += src/libwolfpkcs11.la
 tests_aes_gcm_multipart_test_LDADD += src/libwolfpkcs11.la
 tests_aes_keywrap_pad_test_LDADD += src/libwolfpkcs11.la
 tests_mlkem_secret_scrub_test_LDADD += src/libwolfpkcs11.la
+tests_logout_token_key_zero_test_LDADD += src/libwolfpkcs11.la
 endif
 
 EXTRA_DIST += tests/unit.h \

--- a/tests/include.am
+++ b/tests/include.am
@@ -235,6 +235,11 @@ noinst_PROGRAMS += tests/logout_token_key_zero_test
 tests_logout_token_key_zero_test_SOURCES = tests/logout_token_key_zero_test.c
 tests_logout_token_key_zero_test_LDADD =
 
+check_PROGRAMS += tests/tpm_decode_bounds_test
+noinst_PROGRAMS += tests/tpm_decode_bounds_test
+tests_tpm_decode_bounds_test_SOURCES = tests/tpm_decode_bounds_test.c
+tests_tpm_decode_bounds_test_LDADD =
+
 if BUILD_STATIC
 tests_pkcs11test_LDADD += src/libwolfpkcs11.la
 tests_pkcs11mtt_LDADD  += src/libwolfpkcs11.la
@@ -283,6 +288,7 @@ tests_aes_gcm_multipart_test_LDADD += src/libwolfpkcs11.la
 tests_aes_keywrap_pad_test_LDADD += src/libwolfpkcs11.la
 tests_mlkem_secret_scrub_test_LDADD += src/libwolfpkcs11.la
 tests_logout_token_key_zero_test_LDADD += src/libwolfpkcs11.la
+tests_tpm_decode_bounds_test_LDADD += src/libwolfpkcs11.la
 else
 tests_object_id_uniqueness_test_LDADD += src/libwolfpkcs11.la
 tests_empty_pin_store_test_LDADD += src/libwolfpkcs11.la
@@ -323,6 +329,7 @@ tests_aes_gcm_multipart_test_LDADD += src/libwolfpkcs11.la
 tests_aes_keywrap_pad_test_LDADD += src/libwolfpkcs11.la
 tests_mlkem_secret_scrub_test_LDADD += src/libwolfpkcs11.la
 tests_logout_token_key_zero_test_LDADD += src/libwolfpkcs11.la
+tests_tpm_decode_bounds_test_LDADD += src/libwolfpkcs11.la
 endif
 
 EXTRA_DIST += tests/unit.h \

--- a/tests/include.am
+++ b/tests/include.am
@@ -225,6 +225,11 @@ noinst_PROGRAMS += tests/aes_keywrap_pad_test
 tests_aes_keywrap_pad_test_SOURCES = tests/aes_keywrap_pad_test.c
 tests_aes_keywrap_pad_test_LDADD =
 
+check_PROGRAMS += tests/mlkem_secret_scrub_test
+noinst_PROGRAMS += tests/mlkem_secret_scrub_test
+tests_mlkem_secret_scrub_test_SOURCES = tests/mlkem_secret_scrub_test.c
+tests_mlkem_secret_scrub_test_LDADD =
+
 if BUILD_STATIC
 tests_pkcs11test_LDADD += src/libwolfpkcs11.la
 tests_pkcs11mtt_LDADD  += src/libwolfpkcs11.la
@@ -271,6 +276,7 @@ tests_rsa_private_usage_default_test_LDADD += src/libwolfpkcs11.la
 tests_copyobject_token_test_LDADD += src/libwolfpkcs11.la
 tests_aes_gcm_multipart_test_LDADD += src/libwolfpkcs11.la
 tests_aes_keywrap_pad_test_LDADD += src/libwolfpkcs11.la
+tests_mlkem_secret_scrub_test_LDADD += src/libwolfpkcs11.la
 else
 tests_object_id_uniqueness_test_LDADD += src/libwolfpkcs11.la
 tests_empty_pin_store_test_LDADD += src/libwolfpkcs11.la
@@ -309,6 +315,7 @@ tests_rsa_private_usage_default_test_LDADD += src/libwolfpkcs11.la
 tests_copyobject_token_test_LDADD += src/libwolfpkcs11.la
 tests_aes_gcm_multipart_test_LDADD += src/libwolfpkcs11.la
 tests_aes_keywrap_pad_test_LDADD += src/libwolfpkcs11.la
+tests_mlkem_secret_scrub_test_LDADD += src/libwolfpkcs11.la
 endif
 
 EXTRA_DIST += tests/unit.h \

--- a/tests/include.am
+++ b/tests/include.am
@@ -220,6 +220,11 @@ noinst_PROGRAMS += tests/aes_gcm_multipart_test
 tests_aes_gcm_multipart_test_SOURCES = tests/aes_gcm_multipart_test.c
 tests_aes_gcm_multipart_test_LDADD =
 
+check_PROGRAMS += tests/aes_keywrap_pad_test
+noinst_PROGRAMS += tests/aes_keywrap_pad_test
+tests_aes_keywrap_pad_test_SOURCES = tests/aes_keywrap_pad_test.c
+tests_aes_keywrap_pad_test_LDADD =
+
 if BUILD_STATIC
 tests_pkcs11test_LDADD += src/libwolfpkcs11.la
 tests_pkcs11mtt_LDADD  += src/libwolfpkcs11.la
@@ -265,6 +270,7 @@ tests_secret_extractable_default_test_LDADD += src/libwolfpkcs11.la
 tests_rsa_private_usage_default_test_LDADD += src/libwolfpkcs11.la
 tests_copyobject_token_test_LDADD += src/libwolfpkcs11.la
 tests_aes_gcm_multipart_test_LDADD += src/libwolfpkcs11.la
+tests_aes_keywrap_pad_test_LDADD += src/libwolfpkcs11.la
 else
 tests_object_id_uniqueness_test_LDADD += src/libwolfpkcs11.la
 tests_empty_pin_store_test_LDADD += src/libwolfpkcs11.la
@@ -302,6 +308,7 @@ tests_secret_extractable_default_test_LDADD += src/libwolfpkcs11.la
 tests_rsa_private_usage_default_test_LDADD += src/libwolfpkcs11.la
 tests_copyobject_token_test_LDADD += src/libwolfpkcs11.la
 tests_aes_gcm_multipart_test_LDADD += src/libwolfpkcs11.la
+tests_aes_keywrap_pad_test_LDADD += src/libwolfpkcs11.la
 endif
 
 EXTRA_DIST += tests/unit.h \

--- a/tests/include.am
+++ b/tests/include.am
@@ -215,6 +215,10 @@ check_PROGRAMS += tests/rsa_private_usage_default_test
 noinst_PROGRAMS += tests/rsa_private_usage_default_test
 tests_rsa_private_usage_default_test_SOURCES = tests/rsa_private_usage_default_test.c
 tests_rsa_private_usage_default_test_LDADD =
+check_PROGRAMS += tests/aes_gcm_multipart_test
+noinst_PROGRAMS += tests/aes_gcm_multipart_test
+tests_aes_gcm_multipart_test_SOURCES = tests/aes_gcm_multipart_test.c
+tests_aes_gcm_multipart_test_LDADD =
 
 if BUILD_STATIC
 tests_pkcs11test_LDADD += src/libwolfpkcs11.la
@@ -260,6 +264,7 @@ tests_derive_inherit_protection_test_LDADD += src/libwolfpkcs11.la
 tests_secret_extractable_default_test_LDADD += src/libwolfpkcs11.la
 tests_rsa_private_usage_default_test_LDADD += src/libwolfpkcs11.la
 tests_copyobject_token_test_LDADD += src/libwolfpkcs11.la
+tests_aes_gcm_multipart_test_LDADD += src/libwolfpkcs11.la
 else
 tests_object_id_uniqueness_test_LDADD += src/libwolfpkcs11.la
 tests_empty_pin_store_test_LDADD += src/libwolfpkcs11.la
@@ -296,6 +301,7 @@ tests_derive_inherit_protection_test_LDADD += src/libwolfpkcs11.la
 tests_secret_extractable_default_test_LDADD += src/libwolfpkcs11.la
 tests_rsa_private_usage_default_test_LDADD += src/libwolfpkcs11.la
 tests_copyobject_token_test_LDADD += src/libwolfpkcs11.la
+tests_aes_gcm_multipart_test_LDADD += src/libwolfpkcs11.la
 endif
 
 EXTRA_DIST += tests/unit.h \

--- a/tests/include.am
+++ b/tests/include.am
@@ -181,6 +181,10 @@ check_PROGRAMS += tests/trust_attr_bufsize_test
 noinst_PROGRAMS += tests/trust_attr_bufsize_test
 tests_trust_attr_bufsize_test_SOURCES = tests/trust_attr_bufsize_test.c
 tests_trust_attr_bufsize_test_LDADD =
+check_PROGRAMS += tests/copyobject_token_test
+noinst_PROGRAMS += tests/copyobject_token_test
+tests_copyobject_token_test_SOURCES = tests/copyobject_token_test.c
+tests_copyobject_token_test_LDADD =
 
 check_PROGRAMS += tests/private_object_empty_pin_test
 noinst_PROGRAMS += tests/private_object_empty_pin_test
@@ -255,6 +259,7 @@ tests_derive_disabled_key_test_LDADD += src/libwolfpkcs11.la
 tests_derive_inherit_protection_test_LDADD += src/libwolfpkcs11.la
 tests_secret_extractable_default_test_LDADD += src/libwolfpkcs11.la
 tests_rsa_private_usage_default_test_LDADD += src/libwolfpkcs11.la
+tests_copyobject_token_test_LDADD += src/libwolfpkcs11.la
 else
 tests_object_id_uniqueness_test_LDADD += src/libwolfpkcs11.la
 tests_empty_pin_store_test_LDADD += src/libwolfpkcs11.la
@@ -290,6 +295,7 @@ tests_derive_disabled_key_test_LDADD += src/libwolfpkcs11.la
 tests_derive_inherit_protection_test_LDADD += src/libwolfpkcs11.la
 tests_secret_extractable_default_test_LDADD += src/libwolfpkcs11.la
 tests_rsa_private_usage_default_test_LDADD += src/libwolfpkcs11.la
+tests_copyobject_token_test_LDADD += src/libwolfpkcs11.la
 endif
 
 EXTRA_DIST += tests/unit.h \

--- a/tests/logout_token_key_zero_test.c
+++ b/tests/logout_token_key_zero_test.c
@@ -94,8 +94,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_RV pkcs11_init(void)
 {

--- a/tests/logout_token_key_zero_test.c
+++ b/tests/logout_token_key_zero_test.c
@@ -1,0 +1,319 @@
+/* logout_token_key_zero_test.c
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfPKCS11.
+ *
+ * wolfPKCS11 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfPKCS11 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ *
+ * White-box test for token-key zeroization on user logout (bug #5524).
+ *
+ * WP11_Slot_Logout() scrubs the in-memory token object-encryption key with
+ * wc_ForceZero() on user logout. Deleting that scrub changes no PKCS#11 return
+ * value or object behaviour, so it was untestable through the public API. This
+ * test uses the DEBUG_WOLFPKCS11-only hook WP11_Slot_TokenKeyIsZero() to observe
+ * the key buffer directly: it must be populated after login and all-zero after
+ * logout.
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
+#include <stdio.h>
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/misc.h>
+
+#ifndef WOLFPKCS11_USER_SETTINGS
+    #include <wolfpkcs11/options.h>
+#endif
+#include <wolfpkcs11/pkcs11.h>
+
+#ifndef HAVE_PKCS11_STATIC
+#include <dlfcn.h>
+#endif
+
+#include "testdata.h"
+
+#if defined(DEBUG_WOLFPKCS11) && !defined(WOLFPKCS11_NO_STORE)
+
+/* DEBUG_WOLFPKCS11-only introspection hook exported by libwolfpkcs11. */
+extern int WP11_Slot_TokenKeyIsZero(CK_SLOT_ID slotId);
+
+#define LOGOUT_KEY_TEST_DIR "./store/logout_token_key_zero_test"
+#define WOLFPKCS11_TOKEN_FILENAME "wp11_token_0000000000000001"
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+#define CHECK_CKR(rv, op, expected) do {                    \
+    if (rv != expected) {                                   \
+        fprintf(stderr, "FAIL: %s: expected %ld, got %ld\n", op, (long)expected, (long)rv); \
+        test_failed++;                                      \
+        result = -1;                                        \
+        goto cleanup;                                       \
+    } else {                                                \
+        printf("PASS: %s\n", op);                           \
+        test_passed++;                                      \
+    }                                                       \
+} while(0)
+
+#define CHECK_COND(cond, op) do {                           \
+    if (!(cond)) {                                          \
+        fprintf(stderr, "FAIL: %s\n", op);                 \
+        test_failed++;                                      \
+        result = -1;                                        \
+        goto cleanup;                                       \
+    } else {                                                \
+        printf("PASS: %s\n", op);                           \
+        test_passed++;                                      \
+    }                                                       \
+} while(0)
+
+#ifndef HAVE_PKCS11_STATIC
+static void* dlib;
+#endif
+static CK_FUNCTION_LIST* funcList;
+static CK_SLOT_ID slot = 0;
+static const char* tokenName = "wolfpkcs11";
+static byte* soPin = (byte*)"password123456";
+static int soPinLen = 14;
+static byte* userPin = (byte*)"someUserPin";
+static int userPinLen = 11;
+
+static CK_RV pkcs11_init(void)
+{
+    CK_RV ret;
+    CK_C_INITIALIZE_ARGS args;
+    CK_SLOT_ID slotList[16];
+    CK_ULONG slotCount = sizeof(slotList) / sizeof(slotList[0]);
+
+#ifndef HAVE_PKCS11_STATIC
+    CK_C_GetFunctionList func;
+
+    dlib = dlopen(WOLFPKCS11_DLL_FILENAME, RTLD_NOW | RTLD_LOCAL);
+    if (dlib == NULL) {
+        fprintf(stderr, "dlopen error: %s\n", dlerror());
+        return -1;
+    }
+    func = (CK_C_GetFunctionList)dlsym(dlib, "C_GetFunctionList");
+    if (func == NULL) {
+        fprintf(stderr, "Failed to get function list function\n");
+        dlclose(dlib);
+        return -1;
+    }
+    ret = func(&funcList);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "Failed to get function list: 0x%lx\n",
+            (unsigned long)ret);
+        dlclose(dlib);
+        return ret;
+    }
+#else
+    ret = C_GetFunctionList(&funcList);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "Failed to get function list: 0x%lx\n",
+            (unsigned long)ret);
+        return ret;
+    }
+#endif
+
+    XMEMSET(&args, 0, sizeof(args));
+    args.flags = CKF_OS_LOCKING_OK;
+    ret = funcList->C_Initialize(&args);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_GetSlotList(CK_TRUE, slotList, &slotCount);
+    if (ret != CKR_OK)
+        return ret;
+
+    if (slotCount > 0)
+        slot = slotList[0];
+    else {
+        fprintf(stderr, "No slots available\n");
+        return CKR_GENERAL_ERROR;
+    }
+
+    return ret;
+}
+
+static CK_RV pkcs11_final(void)
+{
+    if (funcList != NULL) {
+        funcList->C_Finalize(NULL);
+        funcList = NULL;
+    }
+#ifndef HAVE_PKCS11_STATIC
+    if (dlib) {
+        dlclose(dlib);
+        dlib = NULL;
+    }
+#endif
+    return CKR_OK;
+}
+
+static CK_RV pkcs11_init_token(void)
+{
+    unsigned char label[32];
+
+    XMEMSET(label, ' ', sizeof(label));
+    XMEMCPY(label, tokenName, XSTRLEN(tokenName));
+    return funcList->C_InitToken(slot, soPin, soPinLen, label);
+}
+
+static CK_RV pkcs11_set_user_pin(void)
+{
+    CK_SESSION_HANDLE soSession;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+    CK_RV ret;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, &soSession);
+    if (ret != CKR_OK)
+        return ret;
+    ret = funcList->C_Login(soSession, CKU_SO, soPin, soPinLen);
+    if (ret != CKR_OK) {
+        funcList->C_CloseSession(soSession);
+        return ret;
+    }
+    ret = funcList->C_InitPIN(soSession, userPin, userPinLen);
+    funcList->C_Logout(soSession);
+    funcList->C_CloseSession(soSession);
+    return ret;
+}
+
+static void cleanup_test_files(const char* dir)
+{
+    char filepath[512];
+
+    snprintf(filepath, sizeof(filepath), "%s" PATH_SEP "%s", dir,
+             WOLFPKCS11_TOKEN_FILENAME);
+    (void)remove(filepath);
+}
+
+/*
+ * Login as user populates the token key; logout must zeroize it. Two cycles
+ * confirm the key is re-derived and re-scrubbed each time.
+ */
+static int logout_token_key_zero_test(void)
+{
+    CK_RV ret;
+    CK_SESSION_HANDLE session = 0;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+    int result = 0;
+    int cycle;
+
+    printf("\n=== Testing token key zeroization on user logout ===\n");
+
+    cleanup_test_files(LOGOUT_KEY_TEST_DIR);
+
+    ret = pkcs11_init();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: pkcs11_init: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        return -1;
+    }
+    ret = pkcs11_init_token();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: C_InitToken: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+    ret = pkcs11_set_user_pin();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: set user PIN: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, &session);
+    CHECK_CKR(ret, "C_OpenSession", CKR_OK);
+
+    for (cycle = 0; cycle < 2; cycle++) {
+        char msg[64];
+
+        ret = funcList->C_Login(session, CKU_USER, userPin, userPinLen);
+        snprintf(msg, sizeof(msg), "cycle %d: C_Login user", cycle);
+        CHECK_CKR(ret, msg, CKR_OK);
+
+        snprintf(msg, sizeof(msg),
+                 "cycle %d: token key populated after login", cycle);
+        CHECK_COND(WP11_Slot_TokenKeyIsZero(slot) == 0, msg);
+
+        ret = funcList->C_Logout(session);
+        snprintf(msg, sizeof(msg), "cycle %d: C_Logout", cycle);
+        CHECK_CKR(ret, msg, CKR_OK);
+
+        snprintf(msg, sizeof(msg),
+                 "cycle %d: token key zeroized after logout", cycle);
+        CHECK_COND(WP11_Slot_TokenKeyIsZero(slot) == 1, msg);
+    }
+
+cleanup:
+    if (session != 0)
+        funcList->C_CloseSession(session);
+    pkcs11_final();
+    return result;
+}
+
+static void print_results(void)
+{
+    printf("\n=== Test Results ===\n");
+    printf("Tests passed: %d\n", test_passed);
+    printf("Tests failed: %d\n", test_failed);
+
+    if (test_failed == 0)
+        printf("ALL TESTS PASSED!\n");
+    else
+        printf("SOME TESTS FAILED!\n");
+}
+
+int main(int argc, char* argv[])
+{
+#ifndef WOLFPKCS11_NO_ENV
+    XSETENV("WOLFPKCS11_TOKEN_PATH", LOGOUT_KEY_TEST_DIR, 1);
+#endif
+
+    (void)argc;
+    (void)argv;
+
+    printf("=== wolfPKCS11 Logout Token-Key Zeroization Test ===\n");
+
+    (void)logout_token_key_zero_test();
+
+    print_results();
+
+    return (test_failed == 0) ? 0 : 1;
+}
+
+#else /* !DEBUG_WOLFPKCS11 || WOLFPKCS11_NO_STORE */
+
+int main(int argc, char* argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("Debug hook/store not available, skipping logout key zeroization "
+           "test\n");
+    return 0;
+}
+
+#endif /* DEBUG_WOLFPKCS11 && !WOLFPKCS11_NO_STORE */

--- a/tests/mlkem_secret_scrub_test.c
+++ b/tests/mlkem_secret_scrub_test.c
@@ -160,13 +160,17 @@ static void test_free(void* p)
 static void* test_realloc(void* p, size_t n)
 {
     void* np;
-    if (g_armed && p != NULL) {
-        int idx = track_find(p);
+    int idx = -1;
+    /* Locate the tracking entry while p is still valid. */
+    if (g_armed && p != NULL)
+        idx = track_find(p);
+    np = realloc(p, n);
+    /* Only update tracking on success; on failure p is still live and tracked. */
+    if (np != NULL) {
         if (idx >= 0)
             track_remove(idx);
+        track_add(np, n);
     }
-    np = realloc(p, n);
-    track_add(np, n);
     return np;
 }
 

--- a/tests/mlkem_secret_scrub_test.c
+++ b/tests/mlkem_secret_scrub_test.c
@@ -1,0 +1,550 @@
+/* mlkem_secret_scrub_test.c
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfPKCS11.
+ *
+ * wolfPKCS11 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfPKCS11 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ *
+ * White-box test for ML-KEM shared-secret zeroization (bug #6056).
+ *
+ * C_EncapsulateKey/C_DecapsulateKey hold the freshly derived ML-KEM shared
+ * secret in a temporary heap buffer, copy it into the new key object, then
+ * wc_ForceZero() it before XFREE(). Deleting that scrub leaves the plaintext
+ * shared secret in freed heap memory, which no PKCS#11-level test can observe.
+ *
+ * This test installs a tracking allocator that snapshots the contents of every
+ * buffer freed during a C_EncapsulateKey/C_DecapsulateKey call, then asserts
+ * the (extractable) shared secret never appears in any freed buffer. With the
+ * scrub present the temporary buffer is zero at free; deleting the scrub makes
+ * this test fail.
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/misc.h>
+#include <wolfssl/wolfcrypt/memory.h>
+
+#ifndef WOLFPKCS11_USER_SETTINGS
+    #include <wolfpkcs11/options.h>
+#endif
+#include <wolfpkcs11/pkcs11.h>
+
+#ifndef HAVE_PKCS11_STATIC
+#include <dlfcn.h>
+#endif
+
+#include "testdata.h"
+
+#if defined(WOLFPKCS11_MLKEM) && defined(WOLFPKCS11_PKCS11_V3_2)
+
+#define MLKEM_SCRUB_TEST_DIR "./store/mlkem_secret_scrub_test"
+#define WOLFPKCS11_TOKEN_FILENAME "wp11_token_0000000000000001"
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+#define CHECK_CKR(rv, op, expected) do {                    \
+    if (rv != expected) {                                   \
+        fprintf(stderr, "FAIL: %s: expected %ld, got %ld\n", op, (long)expected, (long)rv); \
+        test_failed++;                                      \
+        result = -1;                                        \
+        goto cleanup;                                       \
+    } else {                                                \
+        printf("PASS: %s\n", op);                           \
+        test_passed++;                                      \
+    }                                                       \
+} while(0)
+
+#define CHECK_COND(cond, op) do {                           \
+    if (!(cond)) {                                          \
+        fprintf(stderr, "FAIL: %s\n", op);                 \
+        test_failed++;                                      \
+        result = -1;                                        \
+        goto cleanup;                                       \
+    } else {                                                \
+        printf("PASS: %s\n", op);                           \
+        test_passed++;                                      \
+    }                                                       \
+} while(0)
+
+/* ------------------------------------------------------------------ */
+/* Tracking allocator: while armed, snapshots the bytes of every freed */
+/* buffer that was allocated during the same window.                   */
+/* ------------------------------------------------------------------ */
+#define TRK_MAX  16384
+#define CAP_MAX  16384
+#define CAP_BYTES 64
+
+static int    g_armed = 0;
+static void*  g_trkPtr[TRK_MAX];
+static size_t g_trkSz[TRK_MAX];
+static int    g_trkN = 0;
+static size_t g_capSz[CAP_MAX];
+static unsigned char g_capBuf[CAP_MAX][CAP_BYTES];
+static int    g_capN = 0;
+
+static void track_add(void* p, size_t sz)
+{
+    if (g_armed && p != NULL && g_trkN < TRK_MAX) {
+        g_trkPtr[g_trkN] = p;
+        g_trkSz[g_trkN] = sz;
+        g_trkN++;
+    }
+}
+
+static int track_find(void* p)
+{
+    int i;
+    for (i = g_trkN - 1; i >= 0; i--) {
+        if (g_trkPtr[i] == p)
+            return i;
+    }
+    return -1;
+}
+
+static void track_remove(int idx)
+{
+    g_trkN--;
+    g_trkPtr[idx] = g_trkPtr[g_trkN];
+    g_trkSz[idx] = g_trkSz[g_trkN];
+}
+
+static void* test_malloc(size_t n)
+{
+    void* p = malloc(n);
+    track_add(p, n);
+    return p;
+}
+
+static void test_free(void* p)
+{
+    if (g_armed && p != NULL) {
+        int idx = track_find(p);
+        if (idx >= 0) {
+            size_t sz = g_trkSz[idx];
+            if (g_capN < CAP_MAX) {
+                size_t copy = sz < CAP_BYTES ? sz : CAP_BYTES;
+                g_capSz[g_capN] = sz;
+                memcpy(g_capBuf[g_capN], p, copy);
+                g_capN++;
+            }
+            track_remove(idx);
+        }
+    }
+    free(p);
+}
+
+static void* test_realloc(void* p, size_t n)
+{
+    void* np;
+    if (g_armed && p != NULL) {
+        int idx = track_find(p);
+        if (idx >= 0)
+            track_remove(idx);
+    }
+    np = realloc(p, n);
+    track_add(np, n);
+    return np;
+}
+
+static void arm_capture(void)
+{
+    g_trkN = 0;
+    g_capN = 0;
+    g_armed = 1;
+}
+
+static void disarm_capture(void)
+{
+    g_armed = 0;
+}
+
+/* Returns 1 if the secret appears (unscrubbed) in any captured freed buffer. */
+static int secret_found_in_freed(const unsigned char* secret, size_t len)
+{
+    int i;
+    if (len > CAP_BYTES)
+        len = CAP_BYTES;
+    for (i = 0; i < g_capN; i++) {
+        if (g_capSz[i] == len && memcmp(g_capBuf[i], secret, len) == 0)
+            return 1;
+    }
+    return 0;
+}
+
+#ifndef HAVE_PKCS11_STATIC
+static void* dlib;
+#endif
+static CK_FUNCTION_LIST* funcList;
+static CK_SLOT_ID slot = 0;
+static const char* tokenName = "wolfpkcs11";
+static byte* soPin = (byte*)"password123456";
+static int soPinLen = 14;
+static byte* userPin = (byte*)"someUserPin";
+static int userPinLen = 11;
+
+static CK_BBOOL ckTrue = CK_TRUE;
+
+static CK_RV pkcs11_init(void)
+{
+    CK_RV ret;
+    CK_C_INITIALIZE_ARGS args;
+    CK_SLOT_ID slotList[16];
+    CK_ULONG slotCount = sizeof(slotList) / sizeof(slotList[0]);
+    CK_INTERFACE* interface = NULL;
+    /* Request the PKCS#11 v3.2 interface so the function list includes
+     * C_EncapsulateKey/C_DecapsulateKey. */
+    CK_UTF8CHAR_PTR interfaceName = (CK_UTF8CHAR_PTR)"PKCS 11";
+
+#ifndef HAVE_PKCS11_STATIC
+    CK_C_GetInterface func;
+
+    dlib = dlopen(WOLFPKCS11_DLL_FILENAME, RTLD_NOW | RTLD_LOCAL);
+    if (dlib == NULL) {
+        fprintf(stderr, "dlopen error: %s\n", dlerror());
+        return -1;
+    }
+    func = (CK_C_GetInterface)dlsym(dlib, "C_GetInterface");
+    if (func == NULL) {
+        fprintf(stderr, "Failed to get C_GetInterface\n");
+        dlclose(dlib);
+        return -1;
+    }
+    ret = func(interfaceName, NULL, &interface, 0);
+    if (ret != CKR_OK || interface == NULL) {
+        fprintf(stderr, "Failed to get interface: 0x%lx\n",
+            (unsigned long)ret);
+        dlclose(dlib);
+        return ret == CKR_OK ? CKR_GENERAL_ERROR : ret;
+    }
+#else
+    ret = C_GetInterface(interfaceName, NULL, &interface, 0);
+    if (ret != CKR_OK || interface == NULL) {
+        fprintf(stderr, "Failed to get interface: 0x%lx\n",
+            (unsigned long)ret);
+        return ret == CKR_OK ? CKR_GENERAL_ERROR : ret;
+    }
+#endif
+    funcList = (CK_FUNCTION_LIST*)interface->pFunctionList;
+
+    XMEMSET(&args, 0, sizeof(args));
+    args.flags = CKF_OS_LOCKING_OK;
+    ret = funcList->C_Initialize(&args);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_GetSlotList(CK_TRUE, slotList, &slotCount);
+    if (ret != CKR_OK)
+        return ret;
+
+    if (slotCount > 0)
+        slot = slotList[0];
+    else {
+        fprintf(stderr, "No slots available\n");
+        return CKR_GENERAL_ERROR;
+    }
+
+    return ret;
+}
+
+static CK_RV pkcs11_final(void)
+{
+    if (funcList != NULL) {
+        funcList->C_Finalize(NULL);
+        funcList = NULL;
+    }
+#ifndef HAVE_PKCS11_STATIC
+    if (dlib) {
+        dlclose(dlib);
+        dlib = NULL;
+    }
+#endif
+    return CKR_OK;
+}
+
+static CK_RV pkcs11_init_token(void)
+{
+    unsigned char label[32];
+
+    XMEMSET(label, ' ', sizeof(label));
+    XMEMCPY(label, tokenName, XSTRLEN(tokenName));
+    return funcList->C_InitToken(slot, soPin, soPinLen, label);
+}
+
+static CK_RV pkcs11_set_user_pin(void)
+{
+    CK_SESSION_HANDLE soSession;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+    CK_RV ret;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, &soSession);
+    if (ret != CKR_OK)
+        return ret;
+    ret = funcList->C_Login(soSession, CKU_SO, soPin, soPinLen);
+    if (ret != CKR_OK) {
+        funcList->C_CloseSession(soSession);
+        return ret;
+    }
+    ret = funcList->C_InitPIN(soSession, userPin, userPinLen);
+    funcList->C_Logout(soSession);
+    funcList->C_CloseSession(soSession);
+    return ret;
+}
+
+static CK_RV pkcs11_open_session(CK_SESSION_HANDLE* session)
+{
+    CK_RV ret;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, session);
+    if (ret != CKR_OK)
+        return ret;
+    ret = funcList->C_Login(*session, CKU_USER, userPin, userPinLen);
+    if (ret != CKR_OK) {
+        funcList->C_CloseSession(*session);
+        return ret;
+    }
+    return CKR_OK;
+}
+
+static CK_RV pkcs11_close_session(CK_SESSION_HANDLE session)
+{
+    funcList->C_Logout(session);
+    return funcList->C_CloseSession(session);
+}
+
+static void cleanup_test_files(const char* dir)
+{
+    char filepath[512];
+
+    snprintf(filepath, sizeof(filepath), "%s" PATH_SEP "%s", dir,
+             WOLFPKCS11_TOKEN_FILENAME);
+    (void)remove(filepath);
+}
+
+static CK_RV gen_mlkem_keys(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE* pub,
+                            CK_OBJECT_HANDLE* priv)
+{
+    CK_MECHANISM mech;
+    CK_ML_KEM_PARAMETER_SET_TYPE paramSet = CKP_ML_KEM_768;
+    CK_ATTRIBUTE pubTmpl[] = {
+        { CKA_PARAMETER_SET, &paramSet, sizeof(paramSet) },
+        { CKA_ENCAPSULATE,   &ckTrue,   sizeof(ckTrue)   },
+        { CKA_TOKEN,         &ckTrue,   sizeof(ckTrue)   },
+    };
+    CK_ATTRIBUTE privTmpl[] = {
+        { CKA_DECAPSULATE,   &ckTrue,   sizeof(ckTrue)   },
+        { CKA_TOKEN,         &ckTrue,   sizeof(ckTrue)   },
+    };
+
+    mech.mechanism = CKM_ML_KEM_KEY_PAIR_GEN;
+    mech.pParameter = NULL;
+    mech.ulParameterLen = 0;
+
+    return funcList->C_GenerateKeyPair(session, &mech,
+                pubTmpl, sizeof(pubTmpl) / sizeof(*pubTmpl),
+                privTmpl, sizeof(privTmpl) / sizeof(*privTmpl), pub, priv);
+}
+
+static int mlkem_secret_scrub_test(void)
+{
+    CK_RV ret;
+    CK_SESSION_HANDLE session = 0;
+    CK_OBJECT_HANDLE pub = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE priv = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE encapKey = CK_INVALID_HANDLE;
+    CK_OBJECT_HANDLE decapKey = CK_INVALID_HANDLE;
+    CK_FUNCTION_LIST_3_2* funcListExt;
+    CK_MECHANISM mech;
+    CK_BYTE* ciphertext = NULL;
+    CK_ULONG ctLen = 0;
+    CK_BYTE ss1[64], ss2[64];
+    CK_ULONG ss1Len = sizeof(ss1), ss2Len = sizeof(ss2);
+    int result = 0;
+    CK_OBJECT_CLASS secretClass = CKO_SECRET_KEY;
+    CK_KEY_TYPE genericKeyType = CKK_GENERIC_SECRET;
+    CK_BBOOL extractable = CK_TRUE;
+    CK_BBOOL sensitive = CK_FALSE;
+    CK_ATTRIBUTE secretTmpl[] = {
+        { CKA_CLASS,       &secretClass,    sizeof(secretClass)    },
+        { CKA_KEY_TYPE,    &genericKeyType, sizeof(genericKeyType) },
+        { CKA_SENSITIVE,   &sensitive,      sizeof(sensitive)      },
+        { CKA_EXTRACTABLE, &extractable,    sizeof(extractable)    },
+    };
+    CK_ULONG secretTmplCnt = sizeof(secretTmpl) / sizeof(*secretTmpl);
+    CK_ATTRIBUTE getValueTmpl[] = { { CKA_VALUE, NULL, 0 } };
+
+    printf("\n=== Testing ML-KEM shared-secret zeroization ===\n");
+
+    cleanup_test_files(MLKEM_SCRUB_TEST_DIR);
+
+    ret = pkcs11_init();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: pkcs11_init: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        return -1;
+    }
+    funcListExt = (CK_FUNCTION_LIST_3_2*)funcList;
+
+    ret = pkcs11_init_token();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: C_InitToken: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+    ret = pkcs11_set_user_pin();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: set user PIN: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+    ret = pkcs11_open_session(&session);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: pkcs11_open_session: 0x%lx\n",
+                (unsigned long)ret);
+        test_failed++;
+        pkcs11_final();
+        return -1;
+    }
+
+    ret = gen_mlkem_keys(session, &pub, &priv);
+    CHECK_CKR(ret, "ML-KEM key generation", CKR_OK);
+
+    mech.mechanism = CKM_ML_KEM;
+    mech.pParameter = NULL;
+    mech.ulParameterLen = 0;
+
+    /* Ciphertext size query (not armed: no shared secret is derived). */
+    ret = funcListExt->C_EncapsulateKey(session, &mech, pub, secretTmpl,
+                                        secretTmplCnt, NULL, &ctLen, &encapKey);
+    CHECK_CKR(ret, "ML-KEM Encapsulate size query", CKR_OK);
+    ciphertext = (CK_BYTE*)malloc(ctLen);
+    CHECK_COND(ciphertext != NULL, "allocate ciphertext buffer");
+
+    /* Real encapsulate, with freed-buffer capture armed. */
+    arm_capture();
+    ret = funcListExt->C_EncapsulateKey(session, &mech, pub, secretTmpl,
+                                        secretTmplCnt, ciphertext, &ctLen,
+                                        &encapKey);
+    disarm_capture();
+    CHECK_CKR(ret, "ML-KEM Encapsulate", CKR_OK);
+
+    getValueTmpl[0].pValue = ss1;
+    getValueTmpl[0].ulValueLen = ss1Len;
+    ret = funcList->C_GetAttributeValue(session, encapKey, getValueTmpl, 1);
+    CHECK_CKR(ret, "Get encapsulated shared secret", CKR_OK);
+    ss1Len = getValueTmpl[0].ulValueLen;
+    CHECK_COND(ss1Len > 0 && ss1Len <= sizeof(ss1), "shared secret length sane");
+
+    CHECK_COND(!secret_found_in_freed(ss1, ss1Len),
+               "Encapsulate: shared secret scrubbed from freed buffer");
+
+    /* Real decapsulate, with capture armed. */
+    arm_capture();
+    ret = funcListExt->C_DecapsulateKey(session, &mech, priv, secretTmpl,
+                                        secretTmplCnt, ciphertext, ctLen,
+                                        &decapKey);
+    disarm_capture();
+    CHECK_CKR(ret, "ML-KEM Decapsulate", CKR_OK);
+
+    getValueTmpl[0].pValue = ss2;
+    getValueTmpl[0].ulValueLen = ss2Len;
+    ret = funcList->C_GetAttributeValue(session, decapKey, getValueTmpl, 1);
+    CHECK_CKR(ret, "Get decapsulated shared secret", CKR_OK);
+    ss2Len = getValueTmpl[0].ulValueLen;
+
+    CHECK_COND(ss1Len == ss2Len && XMEMCMP(ss1, ss2, ss1Len) == 0,
+               "Encap/decap shared secrets match");
+
+    CHECK_COND(!secret_found_in_freed(ss2, ss2Len),
+               "Decapsulate: shared secret scrubbed from freed buffer");
+
+cleanup:
+    if (ciphertext != NULL)
+        free(ciphertext);
+    if (decapKey != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, decapKey);
+    if (encapKey != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, encapKey);
+    if (priv != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, priv);
+    if (pub != CK_INVALID_HANDLE)
+        funcList->C_DestroyObject(session, pub);
+    pkcs11_close_session(session);
+    pkcs11_final();
+    return result;
+}
+
+static void print_results(void)
+{
+    printf("\n=== Test Results ===\n");
+    printf("Tests passed: %d\n", test_passed);
+    printf("Tests failed: %d\n", test_failed);
+
+    if (test_failed == 0)
+        printf("ALL TESTS PASSED!\n");
+    else
+        printf("SOME TESTS FAILED!\n");
+}
+
+int main(int argc, char* argv[])
+{
+#ifndef WOLFPKCS11_NO_ENV
+    XSETENV("WOLFPKCS11_TOKEN_PATH", MLKEM_SCRUB_TEST_DIR, 1);
+#endif
+
+    (void)argc;
+    (void)argv;
+
+    printf("=== wolfPKCS11 ML-KEM Shared-Secret Scrub Test ===\n");
+
+    /* Install the tracking allocator before any library allocation. */
+    if (wolfSSL_SetAllocators(test_malloc, test_free, test_realloc) != 0) {
+        fprintf(stderr, "FAIL: wolfSSL_SetAllocators\n");
+        return 1;
+    }
+
+    (void)mlkem_secret_scrub_test();
+
+    print_results();
+
+    return (test_failed == 0) ? 0 : 1;
+}
+
+#else /* !WOLFPKCS11_MLKEM || !WOLFPKCS11_PKCS11_V3_2 */
+
+int main(int argc, char* argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("ML-KEM v3.2 not available, skipping shared-secret scrub test\n");
+    return 0;
+}
+
+#endif /* WOLFPKCS11_MLKEM && WOLFPKCS11_PKCS11_V3_2 */

--- a/tests/mlkem_secret_scrub_test.c
+++ b/tests/mlkem_secret_scrub_test.c
@@ -207,8 +207,8 @@ static CK_SLOT_ID slot = 0;
 static const char* tokenName = "wolfpkcs11";
 static byte* soPin = (byte*)"password123456";
 static int soPinLen = 14;
-static byte* userPin = (byte*)"someUserPin";
-static int userPinLen = 11;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
 
 static CK_BBOOL ckTrue = CK_TRUE;
 

--- a/tests/tpm_decode_bounds_test.c
+++ b/tests/tpm_decode_bounds_test.c
@@ -1,0 +1,141 @@
+/* tpm_decode_bounds_test.c
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfPKCS11.
+ *
+ * wolfPKCS11 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfPKCS11 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ *
+ * Test for WP11_Object_DecodeTpmKey storage-blob bounds checking (bug #3839).
+ *
+ * The decoder read pubAreaSize, the public area, priv.size and priv.buffer from
+ * object->keyData without validating offsets against object->keyDataLen. A
+ * truncated/corrupt on-disk TPM blob (which is not protected by the token master
+ * key) therefore caused out-of-bounds heap reads. Each truncated blob below is
+ * placed in a tight heap allocation, so an unpatched decoder reads past it (an
+ * AddressSanitizer build aborts), while the patched decoder returns BUFFER_E.
+ *
+ * Exercised through the DEBUG_WOLFPKCS11-only hook WP11_Test_DecodeTpmKey(),
+ * which runs the static decoder against a caller-supplied blob without needing
+ * a live TPM (a truncated blob is rejected before any TPM interaction).
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
+
+#ifndef WOLFPKCS11_USER_SETTINGS
+    #include <wolfpkcs11/options.h>
+#endif
+#include <wolfpkcs11/pkcs11.h>
+
+#if defined(WOLFPKCS11_TPM) && defined(DEBUG_WOLFPKCS11) && \
+    (!defined(NO_RSA) || defined(HAVE_ECC))
+
+/* DEBUG_WOLFPKCS11-only hook exported by libwolfpkcs11. */
+extern int WP11_Test_DecodeTpmKey(CK_SLOT_ID slotId, unsigned char* keyData,
+    int keyDataLen);
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+/*
+ * Decode a truncated blob of total length 'len'. When len >= 2 the first two
+ * bytes carry pubAreaSize. The blob is allocated to exactly 'len' bytes so any
+ * read past it is a heap overflow. The patched decoder must return BUFFER_E.
+ */
+static void run_case(int len, unsigned short pubAreaSize, const char* label)
+{
+    unsigned char* buf;
+    int ret;
+
+    /* Allocate exactly len bytes (at least 1 so the pointer is non-NULL) so an
+     * out-of-bounds read is detectable. */
+    buf = (unsigned char*)malloc(len < 1 ? 1 : (size_t)len);
+    if (buf == NULL) {
+        fprintf(stderr, "FAIL: %s: malloc\n", label);
+        test_failed++;
+        return;
+    }
+    if (len >= 2)
+        memcpy(buf, &pubAreaSize, sizeof(pubAreaSize));
+
+    ret = WP11_Test_DecodeTpmKey(1, buf, len);
+    free(buf);
+
+    if (ret == BUFFER_E) {
+        printf("PASS: %s (BUFFER_E)\n", label);
+        test_passed++;
+    }
+    else {
+        fprintf(stderr, "FAIL: %s: expected BUFFER_E, got %d\n", label, ret);
+        test_failed++;
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("=== wolfPKCS11 TPM Decode Bounds Test ===\n\n");
+
+    /* keyDataLen too small for the 2-byte pubAreaSize. */
+    run_case(0, 0, "len=0 (no pubAreaSize)");
+    run_case(1, 0, "len=1 (partial pubAreaSize)");
+
+    /* pubAreaSize present but blob too small for the declared public area. */
+    run_case(2, 0,   "len=2 pubAreaSize=0 (no public area)");
+    run_case(3, 1,   "len=3 pubAreaSize=1 (public area truncated)");
+    run_case(5, 4,   "len=5 pubAreaSize=4 (public area truncated)");
+    run_case(6, 10,  "len=6 pubAreaSize=10 (public area truncated)");
+    run_case(8, 32,  "len=8 pubAreaSize=32 (public area truncated)");
+
+    /* pubAreaSize larger than the parse buffer must also be rejected. */
+    run_case(4, 0xFFFF, "len=4 pubAreaSize=65535 (oversized)");
+
+    printf("\n=== Test Results ===\n");
+    printf("Tests passed: %d\n", test_passed);
+    printf("Tests failed: %d\n", test_failed);
+    if (test_failed == 0)
+        printf("ALL TESTS PASSED!\n");
+    else
+        printf("SOME TESTS FAILED!\n");
+
+    return (test_failed == 0) ? 0 : 1;
+}
+
+#else /* !WOLFPKCS11_TPM || !DEBUG_WOLFPKCS11 */
+
+int main(int argc, char* argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("TPM/debug not available, skipping TPM decode bounds test\n");
+    return 0;
+}
+
+#endif

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -652,7 +652,7 @@ WP11_LOCAL int WP11_AesGcm_EncryptUpdate(unsigned char* plain, word32 plainSz,
                               unsigned char* enc, word32* encSz,
                               WP11_Object* secret, WP11_Session* session);
 WP11_LOCAL int WP11_AesGcm_EncryptFinal(unsigned char* enc, word32* encSz,
-                             WP11_Session* session);
+                             WP11_Object* secret, WP11_Session* session);
 WP11_LOCAL int WP11_AesGcm_Decrypt(unsigned char* enc, word32 encSz, unsigned char* dec,
                         word32* decSz, WP11_Object* secret,
                         WP11_Session* session);

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -386,6 +386,10 @@ WP11_LOCAL int WP11_Slot_IsLoggedIn(WP11_Slot* slot);
 WP11_LOCAL void WP11_Slot_Logout(WP11_Slot* slot);
 #ifdef DEBUG_WOLFPKCS11
 WP11_API int WP11_Slot_TokenKeyIsZero(CK_SLOT_ID slotId);
+#if defined(WOLFPKCS11_TPM) && (!defined(NO_RSA) || defined(HAVE_ECC))
+WP11_API int WP11_Test_DecodeTpmKey(CK_SLOT_ID slotId, unsigned char* keyData,
+    int keyDataLen);
+#endif
 #endif
 WP11_LOCAL int WP11_Slot_SetSOPin(WP11_Slot* slot, char* pin, int pinLen);
 WP11_LOCAL int WP11_Slot_SetUserPin(WP11_Slot* slot, char* pin, int pinLen);

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -384,6 +384,9 @@ WP11_LOCAL int WP11_Slot_SOLogin(WP11_Slot* slot, char* pin, int pinLen);
 WP11_LOCAL int WP11_Slot_UserLogin(WP11_Slot* slot, char* pin, int pinLen);
 WP11_LOCAL int WP11_Slot_IsLoggedIn(WP11_Slot* slot);
 WP11_LOCAL void WP11_Slot_Logout(WP11_Slot* slot);
+#ifdef DEBUG_WOLFPKCS11
+WP11_API int WP11_Slot_TokenKeyIsZero(CK_SLOT_ID slotId);
+#endif
 WP11_LOCAL int WP11_Slot_SetSOPin(WP11_Slot* slot, char* pin, int pinLen);
 WP11_LOCAL int WP11_Slot_SetUserPin(WP11_Slot* slot, char* pin, int pinLen);
 WP11_LOCAL int WP11_Slot_TokenReset(WP11_Slot* slot, char* pin, int pinLen,

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -680,6 +680,10 @@ WP11_LOCAL int WP11_AesKeyWrap_Encrypt(unsigned char* plain, word32 plainSz,
         unsigned char* enc, word32* encSz, WP11_Session* session);
 WP11_LOCAL int WP11_AesKeyWrap_Decrypt(unsigned char* enc, word32 encSz,
         unsigned char* dec, word32* decSz, WP11_Session* session);
+WP11_LOCAL int WP11_AesKeyWrapPad_Encrypt(unsigned char* plain, word32 plainSz,
+        unsigned char* enc, word32* encSz, WP11_Session* session);
+WP11_LOCAL int WP11_AesKeyWrapPad_Decrypt(unsigned char* enc, word32 encSz,
+        unsigned char* dec, word32* decSz, WP11_Session* session);
 
 WP11_LOCAL int WP11_AesCts_Encrypt(unsigned char* plain, word32 plainSz,
                         unsigned char* enc, word32* encSz,


### PR DESCRIPTION
This branch continues the PKCS#11 conformance work with a set of fixes and accompanying tests (tracked as F-* items):

**Fixes / features**
- **F-4534** Inherit `CKA_TOKEN` from the source object in `C_CopyObject`
- **F-4068** Fix multi-part `CKM_AES_GCM` encrypt to match single-shot output (streaming AES-GCM)
- **F-6060** Implement RFC 5649 for `CKM_AES_KEY_WRAP_PAD`
- **F-3839** Bounds-check the TPM key blob in `WP11_Object_DecodeTpmKey`

**New tests**
- **F-6056** White-box test for ML-KEM shared-secret zeroization
- **F-5524** White-box test for token-key zeroization on logout
- **F-6060** Cover `C_UnwrapKey` rejection paths and empty-input rejection in the key-wrap-pad test
