### PR TITLE
Fix CK_ULONG length truncation in C_GenerateRandom and C_SeedRandom

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -31,14 +31,26 @@
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/error-crypt.h>
 #include <wolfssl/wolfcrypt/asn.h>
+#include <wolfssl/wolfcrypt/random.h>
 
 #include <wolfpkcs11/pkcs11.h>
 #include <wolfpkcs11/internal.h>
+
+#include <limits.h>
 
 #define ATTR_TYPE_ULONG        0
 #define ATTR_TYPE_BOOL         1
 #define ATTR_TYPE_DATA         2
 #define ATTR_TYPE_DATE         3
+
+/* Maximum number of random bytes generated per call to
+ * WP11_Slot_GenerateRandom(). A CK_ULONG request larger than this is split
+ * into several calls so that (a) the full buffer is filled rather than the
+ * length being silently truncated when cast to the int the lower layer takes,
+ * and (b) the RNG lock is not held for the duration of one huge request.
+ * wc_RNG_GenerateBlock() rejects any single request larger than
+ * RNG_MAX_BLOCK_LEN, so the chunk must not exceed it. */
+#define WOLFPKCS11_RNG_MAX_GEN  ((CK_ULONG)RNG_MAX_BLOCK_LEN)
 
 #define PRF_KEY_SIZE            48
 
@@ -9123,6 +9135,16 @@ CK_RV C_SeedRandom(CK_SESSION_HANDLE hSession, CK_BYTE_PTR pSeed,
         return rv;
     }
 
+    /* The seed is passed to the RNG as a one-shot nonce whose length is an
+     * int; a length that does not fit cannot be honoured without truncation
+     * (and repeatedly re-seeding would discard, not accumulate, entropy), so
+     * reject it rather than silently using a truncated length. */
+    if (ulSeedLen > (CK_ULONG)INT_MAX) {
+        rv = CKR_ARGUMENTS_BAD;
+        WOLFPKCS11_LEAVE("C_SeedRandom", rv);
+        return rv;
+    }
+
     slot = WP11_Session_GetSlot(session);
     ret = WP11_Slot_SeedRandom(slot, pSeed, (int)ulSeedLen);
     if (ret == MEMORY_E) {
@@ -9186,7 +9208,22 @@ CK_RV C_GenerateRandom(CK_SESSION_HANDLE hSession,
     }
 
     slot = WP11_Session_GetSlot(session);
-    ret = WP11_Slot_GenerateRandom(slot, pRandomData, (int)ulRandomLen);
+    /* ulRandomLen is a CK_ULONG which may exceed the range of the int taken by
+     * WP11_Slot_GenerateRandom(). Generate in bounded chunks so the entire
+     * requested buffer is filled instead of silently truncating the length. */
+    ret = 0;
+    {
+        CK_ULONG offset = 0;
+        while (offset < ulRandomLen) {
+            CK_ULONG remaining = ulRandomLen - offset;
+            int chunk = (remaining > WOLFPKCS11_RNG_MAX_GEN) ?
+                (int)WOLFPKCS11_RNG_MAX_GEN : (int)remaining;
+            ret = WP11_Slot_GenerateRandom(slot, pRandomData + offset, chunk);
+            if (ret != 0)
+                break;
+            offset += (CK_ULONG)chunk;
+        }
+    }
     if (ret == MEMORY_E) {
         rv = CKR_DEVICE_MEMORY;
         WOLFPKCS11_LEAVE("C_GenerateRandom", rv);

--- a/tests/pkcs11test.c
+++ b/tests/pkcs11test.c
@@ -38,6 +38,8 @@
 #include <dlfcn.h>
 #endif
 
+#include <limits.h>
+
 #include "unit.h"
 #include "testdata.h"
 #include <wolfpkcs11/internal.h>
@@ -15876,6 +15878,13 @@ static CK_RV test_random(void* args)
         CHECK_CKR_FAIL(ret, CKR_ARGUMENTS_BAD, "Seed Random no seed");
     }
     if (ret == CKR_OK) {
+        /* A seed length that cannot fit in the int taken by the lower layer
+         * must be rejected, not silently truncated to a small value. INT_MAX
+         * + 1 is the smallest such length on any int width. */
+        ret = funcList->C_SeedRandom(session, seed, ((CK_ULONG)INT_MAX + 1));
+        CHECK_CKR_FAIL(ret, CKR_ARGUMENTS_BAD, "Seed Random oversized length");
+    }
+    if (ret == CKR_OK) {
         ret = funcList->C_GenerateRandom(CK_INVALID_HANDLE, data1,
                                                                  sizeof(data1));
         CHECK_CKR_FAIL(ret, CKR_SESSION_HANDLE_INVALID,
@@ -15884,6 +15893,32 @@ static CK_RV test_random(void* args)
     if (ret == CKR_OK) {
         ret = funcList->C_GenerateRandom(session, NULL, sizeof(data1));
         CHECK_CKR_FAIL(ret, CKR_ARGUMENTS_BAD, "Generate Random no data");
+    }
+    if (ret == CKR_OK) {
+        /* Regression: a request larger than WOLFPKCS11_RNG_MAX_GEN must fill
+         * the whole buffer, not just the first chunk. Truncating the CK_ULONG
+         * length to int would leave the tail untouched while still returning
+         * CKR_OK. Verify the tail past the first chunk is written. */
+        CK_ULONG bigLen = (1024 * 1024) + 4096;
+        unsigned char* big = (unsigned char*)XMALLOC(bigLen, NULL,
+                                                     DYNAMIC_TYPE_TMP_BUFFER);
+        if (big == NULL) {
+            ret = CKR_HOST_MEMORY;
+            CHECK_CKR(ret, "Allocate large random buffer");
+        }
+        if (ret == CKR_OK) {
+            XMEMSET(big, 0xAA, bigLen);
+            ret = funcList->C_GenerateRandom(session, big, bigLen);
+            CHECK_CKR(ret, "Generate Random large");
+        }
+        if (ret == CKR_OK) {
+            b = 0;
+            for (i = 0; i < 32; i++)
+                b |= (unsigned char)(big[bigLen - 32 + i] ^ 0xAA);
+            CHECK_COND(b != 0, ret, "Large generate filled tail of buffer");
+        }
+        if (big != NULL)
+            XFREE(big, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
 
     return ret;


### PR DESCRIPTION
Very briefly, it is a fix for the current behaviour on 64-bit systems:

Demo:
```c
  CK_ULONG    size = 0x100000008UL;                 /* 4 GiB + 8 bytes */
  CK_BYTE_PTR buf  = (CK_BYTE_PTR)calloc(size, 1);   /* zero-filled */
  CK_RV       rv   = C_GenerateRandom(s, buf, size);
  /* rv == CKR_OK, yet only buf[0..7] are randomised; buf[8..] stays 0 (4 GiB of zeros) */
```

Description:

C_GenerateRandom() and C_SeedRandom() cast their CK_ULONG length argument straight to int before calling WP11_Slot_GenerateRandom() / WP11_Slot_SeedRandom(). On LP64 platforms a length above INT_MAX is silently truncated, so e.g. C_GenerateRandom(s, buf, 0x100000008) produced only 8 bytes yet returned CKR_OK, leaving the remainder of the caller's buffer untouched. A caller that trusts the success code then uses uninitialised / predictable memory as key or nonce material. C_GenerateRandom takes no output-length out-parameter, so per PKCS#11 a CKR_OK return must mean the whole buffer was filled.

C_GenerateRandom now generates the buffer in RNG_MAX_BLOCK_LEN-sized chunks using CK_ULONG arithmetic, filling the entire request regardless of size. This also fixes a pre-existing limitation: wc_RNG_GenerateBlock() rejects any single request larger than RNG_MAX_BLOCK_LEN (64 KiB) with BAD_FUNC_ARG, so a single C_GenerateRandom of more than 64 KiB previously failed with CKR_FUNCTION_FAILED.

C_SeedRandom now rejects a seed length that does not fit in the int taken by the lower layer with CKR_ARGUMENTS_BAD (a return value already listed for this function) rather than truncating it; the seed is consumed as a one-shot RNG nonce and cannot be accumulated across calls.

tests/pkcs11test.c: test_random now verifies that an oversized seed length is rejected and that a multi-chunk (>64 KiB) generate request fills the whole buffer.