### PR TITLE
Prevent double free in concurrent C_DestroyObject on shared token object

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1280,7 +1280,7 @@ err_out:
         if (*phKey != CK_INVALID_HANDLE) {
             /* ignore return value, logged in function */
             (void)WP11_Session_RemoveObject(session, privKeyObject,
-                                            WP11_Object_OnToken(privKeyObject));
+                                            WP11_Object_OnToken(privKeyObject), 0);
             *phKey = CK_INVALID_HANDLE;
         }
         if (privKeyObject != NULL) {
@@ -1478,7 +1478,7 @@ CK_RV C_CreateObject(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pTemplate,
     if (rv != CKR_OK) {
         /* ignore return value, logged in function */
         (void)WP11_Session_RemoveObject(session, object,
-                                        WP11_Object_OnToken(object));
+                                        WP11_Object_OnToken(object), 0);
         WP11_Object_Free(object);
     }
 
@@ -1708,16 +1708,12 @@ CK_RV C_DestroyObject(CK_SESSION_HANDLE hSession,
         return rv;
     }
 
-    /* Reject destruction of objects whose CKA_DESTROYABLE has been set to
-     * CK_FALSE. Read the flag bit directly so the gate stays consistent
-     * regardless of which getter view applies. */
-    if (!WP11_Object_IsDestroyable(obj)) {
-        rv = CKR_ACTION_PROHIBITED;
-        WOLFPKCS11_LEAVE("C_DestroyObject", rv);
-        return rv;
-    }
-
-    ret = WP11_Session_RemoveObject(session, obj, onToken);
+    /* Remove and reject-if-not-destroyable in one locked step. The
+     * CKA_DESTROYABLE check is performed inside WP11_Session_RemoveObject, once
+     * the object is confirmed still linked (and therefore alive), so it cannot
+     * race a concurrent free of the same handle. */
+    ret = WP11_Session_RemoveObject(session, obj, onToken,
+                                    1 /* checkDestroyable */);
     if (ret == WP11_OBJECT_ALREADY_REMOVED) {
         /* Another thread destroyed this object first (a concurrent
          * C_DestroyObject on the same shared token-object handle). That thread
@@ -1726,12 +1722,20 @@ CK_RV C_DestroyObject(CK_SESSION_HANDLE hSession,
         WOLFPKCS11_LEAVE("C_DestroyObject", rv);
         return rv;
     }
+    if (ret == WP11_OBJECT_NOT_DESTROYABLE) {
+        /* CKA_DESTROYABLE is CK_FALSE; object left in place. */
+        rv = CKR_ACTION_PROHIBITED;
+        WOLFPKCS11_LEAVE("C_DestroyObject", rv);
+        return rv;
+    }
     /* Drop any active-operation reference to this object before freeing it so a
      * pending operation cannot use freed memory. */
     WP11_Slot_ClearActiveObject(WP11_Session_GetSlot(session), obj);
     WP11_Object_Free(obj);
 
-    rv = CKR_OK;
+    /* The object was unlinked; a negative status means persisting the token
+     * afterwards failed. Surface it rather than reporting success. */
+    rv = (ret < 0) ? CKR_FUNCTION_FAILED : CKR_OK;
     WOLFPKCS11_LEAVE("C_DestroyObject", rv);
     return rv;
 }
@@ -7933,13 +7937,13 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE hSession,
     if (rv != CKR_OK && pub != NULL) {
         if (*phPublicKey != CK_INVALID_HANDLE)
             (void)WP11_Session_RemoveObject(session, pub,
-                                            WP11_Object_OnToken(pub));
+                                            WP11_Object_OnToken(pub), 0);
         WP11_Object_Free(pub);
     }
     if (rv != CKR_OK && priv != NULL) {
         if (*phPrivateKey != CK_INVALID_HANDLE)
             (void)WP11_Session_RemoveObject(session, priv,
-                                            WP11_Object_OnToken(priv));
+                                            WP11_Object_OnToken(priv), 0);
         WP11_Object_Free(priv);
     }
 
@@ -8438,7 +8442,7 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
                 if (*phKey != CK_INVALID_HANDLE) {
                     /* ignore return value, logged in function */
                     (void)WP11_Session_RemoveObject(session, keyObj,
-                                                    WP11_Object_OnToken(keyObj));
+                                                    WP11_Object_OnToken(keyObj), 0);
                     *phKey = CK_INVALID_HANDLE;
                 }
                 if (keyObj != NULL) {

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1279,7 +1279,8 @@ err_out:
     if (rv != CKR_OK) {
         if (*phKey != CK_INVALID_HANDLE) {
             /* ignore return value, logged in function */
-            (void)WP11_Session_RemoveObject(session, privKeyObject);
+            (void)WP11_Session_RemoveObject(session, privKeyObject,
+                                            WP11_Object_OnToken(privKeyObject));
             *phKey = CK_INVALID_HANDLE;
         }
         if (privKeyObject != NULL) {
@@ -1476,7 +1477,8 @@ CK_RV C_CreateObject(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pTemplate,
     rv = AddObject(session, object, pTemplate, ulCount, phObject);
     if (rv != CKR_OK) {
         /* ignore return value, logged in function */
-        (void)WP11_Session_RemoveObject(session, object);
+        (void)WP11_Session_RemoveObject(session, object,
+                                        WP11_Object_OnToken(object));
         WP11_Object_Free(object);
     }
 
@@ -1664,6 +1666,7 @@ CK_RV C_DestroyObject(CK_SESSION_HANDLE hSession,
                       CK_OBJECT_HANDLE hObject)
 {
     int ret;
+    int onToken;
     CK_RV rv;
     WP11_Session* session;
     WP11_Object* obj = NULL;
@@ -1692,9 +1695,14 @@ CK_RV C_DestroyObject(CK_SESSION_HANDLE hSession,
         WOLFPKCS11_LEAVE("C_DestroyObject", rv);
         return rv;
     }
+    /* Derive onToken from the handle, not the object: it stays valid even if a
+     * concurrent destroy of the same handle frees the object out from under
+     * us, and it lets WP11_Session_RemoveObject unlink token objects using
+     * pointer identity alone. */
+    onToken = WP11_Object_HandleOnToken(hObject);
 
     /* Only require R/W session for token objects */
-    if (!WP11_Session_IsRW(session) && WP11_Object_OnToken(obj)) {
+    if (!WP11_Session_IsRW(session) && onToken) {
         rv = CKR_SESSION_READ_ONLY;
         WOLFPKCS11_LEAVE("C_DestroyObject", rv);
         return rv;
@@ -1709,12 +1717,21 @@ CK_RV C_DestroyObject(CK_SESSION_HANDLE hSession,
         return rv;
     }
 
-    rv = WP11_Session_RemoveObject(session, obj);
+    ret = WP11_Session_RemoveObject(session, obj, onToken);
+    if (ret == WP11_OBJECT_ALREADY_REMOVED) {
+        /* Another thread destroyed this object first (a concurrent
+         * C_DestroyObject on the same shared token-object handle). That thread
+         * owns the free; do not touch the object again. */
+        rv = CKR_OBJECT_HANDLE_INVALID;
+        WOLFPKCS11_LEAVE("C_DestroyObject", rv);
+        return rv;
+    }
     /* Drop any active-operation reference to this object before freeing it so a
      * pending operation cannot use freed memory. */
     WP11_Slot_ClearActiveObject(WP11_Session_GetSlot(session), obj);
     WP11_Object_Free(obj);
 
+    rv = CKR_OK;
     WOLFPKCS11_LEAVE("C_DestroyObject", rv);
     return rv;
 }
@@ -7915,12 +7932,14 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE hSession,
 
     if (rv != CKR_OK && pub != NULL) {
         if (*phPublicKey != CK_INVALID_HANDLE)
-            (void)WP11_Session_RemoveObject(session, pub);
+            (void)WP11_Session_RemoveObject(session, pub,
+                                            WP11_Object_OnToken(pub));
         WP11_Object_Free(pub);
     }
     if (rv != CKR_OK && priv != NULL) {
         if (*phPrivateKey != CK_INVALID_HANDLE)
-            (void)WP11_Session_RemoveObject(session, priv);
+            (void)WP11_Session_RemoveObject(session, priv,
+                                            WP11_Object_OnToken(priv));
         WP11_Object_Free(priv);
     }
 
@@ -8418,7 +8437,8 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
             if (rv != CKR_OK) {
                 if (*phKey != CK_INVALID_HANDLE) {
                     /* ignore return value, logged in function */
-                    (void)WP11_Session_RemoveObject(session, keyObj);
+                    (void)WP11_Session_RemoveObject(session, keyObj,
+                                                    WP11_Object_OnToken(keyObj));
                     *phKey = CK_INVALID_HANDLE;
                 }
                 if (keyObj != NULL) {

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -1278,9 +1278,7 @@ static CK_RV AddRSAPrivateKeyObject(WP11_Session* session,
 err_out:
     if (rv != CKR_OK) {
         if (*phKey != CK_INVALID_HANDLE) {
-            /* ignore return value, logged in function */
-            (void)WP11_Session_RemoveObject(session, privKeyObject,
-                                            WP11_Object_OnToken(privKeyObject), 0);
+            WP11_Session_RemoveObject(session, privKeyObject);
             *phKey = CK_INVALID_HANDLE;
         }
         if (privKeyObject != NULL) {
@@ -1476,9 +1474,7 @@ CK_RV C_CreateObject(CK_SESSION_HANDLE hSession, CK_ATTRIBUTE_PTR pTemplate,
     }
     rv = AddObject(session, object, pTemplate, ulCount, phObject);
     if (rv != CKR_OK) {
-        /* ignore return value, logged in function */
-        (void)WP11_Session_RemoveObject(session, object,
-                                        WP11_Object_OnToken(object), 0);
+        WP11_Session_RemoveObject(session, object);
         WP11_Object_Free(object);
     }
 
@@ -1697,8 +1693,8 @@ CK_RV C_DestroyObject(CK_SESSION_HANDLE hSession,
     }
     /* Derive onToken from the handle, not the object: it stays valid even if a
      * concurrent destroy of the same handle frees the object out from under
-     * us, and it lets WP11_Session_RemoveObject unlink token objects using
-     * pointer identity alone. */
+     * us, and it lets WP11_Session_RemoveObjectByHandle unlink token objects
+     * using pointer identity alone. */
     onToken = WP11_Object_HandleOnToken(hObject);
 
     /* Only require R/W session for token objects */
@@ -1709,11 +1705,11 @@ CK_RV C_DestroyObject(CK_SESSION_HANDLE hSession,
     }
 
     /* Remove and reject-if-not-destroyable in one locked step. The
-     * CKA_DESTROYABLE check is performed inside WP11_Session_RemoveObject, once
-     * the object is confirmed still linked (and therefore alive), so it cannot
-     * race a concurrent free of the same handle. */
-    ret = WP11_Session_RemoveObject(session, obj, onToken,
-                                    1 /* checkDestroyable */);
+     * CKA_DESTROYABLE check is performed inside WP11_Session_RemoveObjectByHandle,
+     * once the object is confirmed still linked (and therefore alive), so it
+     * cannot race a concurrent free of the same handle. */
+    ret = WP11_Session_RemoveObjectByHandle(session, obj, onToken,
+                                            1 /* checkDestroyable */);
     if (ret == WP11_OBJECT_ALREADY_REMOVED) {
         /* Another thread destroyed this object first (a concurrent
          * C_DestroyObject on the same shared token-object handle). That thread
@@ -7936,14 +7932,12 @@ CK_RV C_GenerateKeyPair(CK_SESSION_HANDLE hSession,
 
     if (rv != CKR_OK && pub != NULL) {
         if (*phPublicKey != CK_INVALID_HANDLE)
-            (void)WP11_Session_RemoveObject(session, pub,
-                                            WP11_Object_OnToken(pub), 0);
+            WP11_Session_RemoveObject(session, pub);
         WP11_Object_Free(pub);
     }
     if (rv != CKR_OK && priv != NULL) {
         if (*phPrivateKey != CK_INVALID_HANDLE)
-            (void)WP11_Session_RemoveObject(session, priv,
-                                            WP11_Object_OnToken(priv), 0);
+            WP11_Session_RemoveObject(session, priv);
         WP11_Object_Free(priv);
     }
 
@@ -8440,9 +8434,7 @@ CK_RV C_UnwrapKey(CK_SESSION_HANDLE hSession,
             }
             if (rv != CKR_OK) {
                 if (*phKey != CK_INVALID_HANDLE) {
-                    /* ignore return value, logged in function */
-                    (void)WP11_Session_RemoveObject(session, keyObj,
-                                                    WP11_Object_OnToken(keyObj), 0);
+                    WP11_Session_RemoveObject(session, keyObj);
                     *phKey = CK_INVALID_HANDLE;
                 }
                 if (keyObj != NULL) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -922,7 +922,7 @@ static void wp11_Session_Final(WP11_Session* session)
         /* Free objects in session. */
         while ((obj = session->object) != NULL) {
             /* ignore return value, logged in function */
-            (void)WP11_Session_RemoveObject(session, obj, obj->onToken, 0);
+            WP11_Session_RemoveObject(session, obj);
             WP11_Object_Free(obj);
         }
         session->inUse = 0;
@@ -8815,15 +8815,37 @@ int WP11_Session_AddObject(WP11_Session* session, int onToken,
 }
 
 /**
- * Remove object to the session or token.
+ * Remove an object from its session or token list, addressing it by a
+ * caller-supplied onToken flag rather than by dereferencing the object.
  *
- * @param  session  [in]  Session object.
- * @param  object   [in]  Key Object object.
- * @return  -ve on failure.
- *          0 on success.
+ * Membership is established by pointer identity alone, so *object is never
+ * dereferenced until it is confirmed still linked (and therefore still alive).
+ * onToken must be derived from the handle (see WP11_Object_HandleOnToken), not
+ * from *object, so it stays valid even after a concurrent caller frees the
+ * object. This is the entry point for C_DestroyObject, where a second thread may
+ * be destroying the same shared token-object handle at the same time.
+ *
+ * Callers that hold the only reference to a live object should use the simpler
+ * WP11_Session_RemoveObject() wrapper instead: it derives onToken from the
+ * object itself and so cannot mismatch onToken against the wrong object.
+ *
+ * @param  session          [in]  Session performing the removal.
+ * @param  object           [in]  Object to remove, matched by pointer identity.
+ * @param  onToken          [in]  Non-zero if the handle names a token object.
+ *                                Derive from the handle, never from *object.
+ * @param  checkDestroyable [in]  Non-zero to honor CKA_DESTROYABLE and refuse to
+ *                                remove an object marked not destroyable.
+ * @return  WP11_OBJECT_ALREADY_REMOVED if the object was no longer linked, i.e.
+ *          a concurrent caller already removed it; the caller must not free it.
+ *          WP11_OBJECT_NOT_DESTROYABLE if checkDestroyable is set and the object
+ *          has CKA_DESTROYABLE = CK_FALSE; the object is left in place and must
+ *          not be freed.
+ *          -ve on a store failure after the object was unlinked.
+ *          0 on success; the caller now owns the object and must free it.
  */
-int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object,
-                              int onToken, int checkDestroyable)
+int WP11_Session_RemoveObjectByHandle(WP11_Session* session,
+                                      WP11_Object* object, int onToken,
+                                      int checkDestroyable)
 {
     int ret = 0;
     int found = 0;
@@ -8955,6 +8977,25 @@ int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object,
     WP11_Lock_UnlockRW(&token->lock);
     (void)id; /* set but not used with WOLFPKCS11_NO_STORE */
     return ret;
+}
+
+/**
+ * Remove a live, exclusively-owned object from its session or token list.
+ *
+ * Thin wrapper over WP11_Session_RemoveObjectByHandle() for cleanup paths that
+ * hold the only reference to the object (object-creation rollback, keygen
+ * failure). onToken is read from the object itself, which is safe because no
+ * other thread can be removing it, and supplying onToken this way removes any
+ * risk of passing the wrong object's onToken. CKA_DESTROYABLE is not enforced
+ * (internal cleanup is not a user destroy) and any store error is logged in the
+ * callee, so the return value is intentionally discarded.
+ *
+ * @param  session  [in]  Session performing the removal.
+ * @param  object   [in]  Object to remove; must be live and owned by the caller.
+ */
+void WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object)
+{
+    (void)WP11_Session_RemoveObjectByHandle(session, object, object->onToken, 0);
 }
 
 /**
@@ -10291,13 +10332,13 @@ int WP11_Object_Find(WP11_Session* session, CK_OBJECT_HANDLE objHandle,
         /* The NSS cross-session walk below needs the slot lock so a concurrent
          * remove-session can't reclaim a session node. Acquire it before the
          * token lock to match the global lock order (slot then token) used by
-         * WP11_Session_RemoveObject / WP11_Slot_CloseSessions; acquiring them
-         * in the opposite order would risk an AB-BA deadlock. */
+         * WP11_Session_RemoveObjectByHandle / WP11_Slot_CloseSessions; acquiring
+         * them in the opposite order would risk an AB-BA deadlock. */
         WP11_Lock_LockRO(&session->slot->lock);
 #endif
         /* Hold the token lock across the session->object walk so a concurrent
-         * WP11_Session_RemoveObject (which holds the same lock around the
-         * unlink) can't free a node we're stepping through. */
+         * WP11_Session_RemoveObjectByHandle (which holds the same lock around
+         * the unlink) can't free a node we're stepping through. */
         WP11_Lock_LockRO(&session->slot->token.lock);
         obj = session->object;
         while (obj != NULL) {

--- a/src/internal.c
+++ b/src/internal.c
@@ -922,7 +922,7 @@ static void wp11_Session_Final(WP11_Session* session)
         /* Free objects in session. */
         while ((obj = session->object) != NULL) {
             /* ignore return value, logged in function */
-            (void)WP11_Session_RemoveObject(session, obj);
+            (void)WP11_Session_RemoveObject(session, obj, obj->onToken);
             WP11_Object_Free(obj);
         }
         session->inUse = 0;
@@ -8822,44 +8822,54 @@ int WP11_Session_AddObject(WP11_Session* session, int onToken,
  * @return  -ve on failure.
  *          0 on success.
  */
-int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object)
+int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object,
+                              int onToken)
 {
     int ret = 0;
+    int found = 0;
     WP11_Object** curr;
-    WP11_Token* token;
-    int id;
+    WP11_Token* token = &session->slot->token;
+    WP11_Session* owner = session;
+    int id = 0;
 
-#ifdef WOLFPKCS11_NSS
-    if (object->session && (session != object->session))
-        session = object->session;
-#endif
+    /* The token lock guards every object list on the slot (session lists
+     * included). Take it before touching any list. Token objects are shared
+     * across sessions, so two C_DestroyObject calls on the same handle can both
+     * pass the lock-free WP11_Object_Find and reach here with the same pointer;
+     * the loser must detect that the winner already unlinked (and is about to
+     * free) the object and bail out without a second free.
+     *
+     * onToken comes from the handle, not from *object, so it is safe to trust
+     * even after the object has been freed. On the token path membership is
+     * tested purely by pointer identity - the object is never dereferenced
+     * until it is confirmed still linked (and therefore still alive). */
+    WP11_Lock_LockRW(&token->lock);
 
-    /* Find the object in list and relink. */
-    if (object->onToken) {
-        WP11_Lock_LockRW(object->lock);
-        token = &session->slot->token;
+    if (onToken) {
+        /* Confirm the object is still on the shared token list. */
+        for (curr = &token->object; *curr != NULL; curr = &(*curr)->next) {
+            if (*curr == object) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            WP11_Lock_UnlockRW(&token->lock);
+            return WP11_OBJECT_ALREADY_REMOVED;
+        }
+
         token->objCnt--;
         /* Id of first object on token. */
         id = token->objCnt;
         curr = &token->object;
-    }
-    else {
-        session->objCnt--;
-        /* Id of first object in session. */
-        id = session->objCnt;
-        curr = &session->object;
-        WP11_Lock_LockRW(&session->slot->token.lock);
-    }
+        /* walk list to get id for object to remove */
+        while (*curr != NULL) {
+            if (*curr == object) {
+                *curr = object->next;
+                break;
+            }
 
-    /* walk list to get id for object to remove */
-    while (*curr != NULL) {
-        if (*curr == object) {
-            *curr = object->next;
-            break;
-        }
-
-    #ifndef WOLFPKCS11_NO_STORE
-        if (object->onToken) {
+        #ifndef WOLFPKCS11_NO_STORE
             /* remove any id's with higher value */
             ret = wp11_Object_Unstore(*curr, (int)session->slotId, id);
         #ifdef DEBUG_WOLFPKCS11
@@ -8868,16 +8878,14 @@ int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object)
                     (int)session->slotId, id, ret);
             }
         #endif
+        #endif
+
+            curr = &(*curr)->next;
+            /* Id of next object as it isn't the one being removed. */
+            id--;
         }
-    #endif
 
-        curr = &(*curr)->next;
-        /* Id of next object as it isn't the one being removed. */
-        id--;
-    }
-
-    if (object->onToken) {
-#ifndef WOLFPKCS11_NO_STORE
+    #ifndef WOLFPKCS11_NO_STORE
         ret = wp11_Object_Unstore(object, (int)session->slotId, id);
     #ifdef DEBUG_WOLFPKCS11
         if (ret != 0) {
@@ -8893,12 +8901,39 @@ int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object)
                 (int)session->slotId, ret);
         }
     #endif
-#endif
-        WP11_Lock_UnlockRW(object->lock);
+    #endif
     }
     else {
-        WP11_Lock_UnlockRW(&session->slot->token.lock);
+        /* Session object. These are not shared across sessions in the standard
+         * build, so a concurrent destroy of the same session-object handle is
+         * single-session misuse, outside the PKCS#11 threading contract. */
+#ifdef WOLFPKCS11_NSS
+        /* NSS makes objects visible across sessions; remove from the owning
+         * session's list. */
+        if (object->session != NULL && object->session != session)
+            owner = object->session;
+#endif
+        for (curr = &owner->object; *curr != NULL; curr = &(*curr)->next) {
+            if (*curr == object) {
+                found = 1;
+                break;
+            }
+        }
+        if (!found) {
+            WP11_Lock_UnlockRW(&token->lock);
+            return WP11_OBJECT_ALREADY_REMOVED;
+        }
+
+        owner->objCnt--;
+        for (curr = &owner->object; *curr != NULL; curr = &(*curr)->next) {
+            if (*curr == object) {
+                *curr = object->next;
+                break;
+            }
+        }
     }
+
+    WP11_Lock_UnlockRW(&token->lock);
     (void)id; /* set but not used with WOLFPKCS11_NO_STORE */
     return ret;
 }
@@ -10195,6 +10230,22 @@ int WP11_Object_SetClass(WP11_Object* object, CK_OBJECT_CLASS objClass)
         WP11_Lock_UnlockRW(object->lock);
 
     return 0;
+}
+
+/**
+ * Determine whether an object handle refers to a token object.
+ *
+ * The onToken bit is encoded in the handle value itself, so this is safe to
+ * call even when the WP11_Object has already been freed by another thread -
+ * useful when deciding which list a racing C_DestroyObject must consult.
+ *
+ * @param  handle  [in]  Object handle.
+ * @return  1 when the handle refers to a token object.
+ *          0 when the handle refers to a session object.
+ */
+int WP11_Object_HandleOnToken(CK_OBJECT_HANDLE handle)
+{
+    return OBJ_HANDLE_ON_TOKEN(handle);
 }
 
 /**

--- a/src/internal.c
+++ b/src/internal.c
@@ -922,7 +922,7 @@ static void wp11_Session_Final(WP11_Session* session)
         /* Free objects in session. */
         while ((obj = session->object) != NULL) {
             /* ignore return value, logged in function */
-            (void)WP11_Session_RemoveObject(session, obj, obj->onToken);
+            (void)WP11_Session_RemoveObject(session, obj, obj->onToken, 0);
             WP11_Object_Free(obj);
         }
         session->inUse = 0;
@@ -8823,7 +8823,7 @@ int WP11_Session_AddObject(WP11_Session* session, int onToken,
  *          0 on success.
  */
 int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object,
-                              int onToken)
+                              int onToken, int checkDestroyable)
 {
     int ret = 0;
     int found = 0;
@@ -8833,31 +8833,70 @@ int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object,
     int id = 0;
 
     /* The token lock guards every object list on the slot (session lists
-     * included). Take it before touching any list. Token objects are shared
-     * across sessions, so two C_DestroyObject calls on the same handle can both
-     * pass the lock-free WP11_Object_Find and reach here with the same pointer;
-     * the loser must detect that the winner already unlinked (and is about to
-     * free) the object and bail out without a second free.
+     * included). Take it before touching any list or the object. Token objects
+     * are shared across sessions, so two C_DestroyObject calls on the same
+     * handle can both pass the lock-free WP11_Object_Find and reach here with
+     * the same pointer; the loser must detect that the winner already unlinked
+     * (and is about to free) the object and bail out without a second free.
      *
-     * onToken comes from the handle, not from *object, so it is safe to trust
-     * even after the object has been freed. On the token path membership is
-     * tested purely by pointer identity - the object is never dereferenced
-     * until it is confirmed still linked (and therefore still alive). */
+     * Membership is established by pointer identity alone so that *object is
+     * never dereferenced until it is confirmed still linked (and therefore
+     * still alive). onToken comes from the handle, not from *object, so it is
+     * safe to trust even after the object has been freed. */
     WP11_Lock_LockRW(&token->lock);
 
     if (onToken) {
-        /* Confirm the object is still on the shared token list. */
+        /* Token objects live on the shared token list. */
         for (curr = &token->object; *curr != NULL; curr = &(*curr)->next) {
             if (*curr == object) {
                 found = 1;
                 break;
             }
         }
-        if (!found) {
-            WP11_Lock_UnlockRW(&token->lock);
-            return WP11_OBJECT_ALREADY_REMOVED;
+    }
+    else {
+        /* Session objects live on their owning session's list. Check the
+         * caller's own list first: it is the only possibility in the standard
+         * build and the common case under NSS, and needs no dereference of
+         * *object. */
+        for (curr = &owner->object; *curr != NULL; curr = &(*curr)->next) {
+            if (*curr == object) {
+                found = 1;
+                break;
+            }
         }
+#ifdef WOLFPKCS11_NSS
+        /* NSS makes objects visible across sessions, so the object may belong
+         * to a different session. Fall back to its recorded owner. This is
+         * reached only for a genuinely cross-session object - a freed object is
+         * normally caught as not-found above - and carries the same
+         * out-of-contract residual as a single-session concurrent misuse. */
+        if (!found && object->session != NULL && object->session != session) {
+            owner = object->session;
+            for (curr = &owner->object; *curr != NULL; curr = &(*curr)->next) {
+                if (*curr == object) {
+                    found = 1;
+                    break;
+                }
+            }
+        }
+#endif
+    }
 
+    if (!found) {
+        WP11_Lock_UnlockRW(&token->lock);
+        return WP11_OBJECT_ALREADY_REMOVED;
+    }
+
+    /* The object is confirmed linked, and therefore alive, so its fields may
+     * now be read safely under the lock. Enforce CKA_DESTROYABLE here rather
+     * than in the caller so the check cannot race a concurrent free. */
+    if (checkDestroyable && (object->opFlag & WP11_FLAG_NOT_DESTROYABLE)) {
+        WP11_Lock_UnlockRW(&token->lock);
+        return WP11_OBJECT_NOT_DESTROYABLE;
+    }
+
+    if (onToken) {
         token->objCnt--;
         /* Id of first object on token. */
         id = token->objCnt;
@@ -8904,26 +8943,6 @@ int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object,
     #endif
     }
     else {
-        /* Session object. These are not shared across sessions in the standard
-         * build, so a concurrent destroy of the same session-object handle is
-         * single-session misuse, outside the PKCS#11 threading contract. */
-#ifdef WOLFPKCS11_NSS
-        /* NSS makes objects visible across sessions; remove from the owning
-         * session's list. */
-        if (object->session != NULL && object->session != session)
-            owner = object->session;
-#endif
-        for (curr = &owner->object; *curr != NULL; curr = &(*curr)->next) {
-            if (*curr == object) {
-                found = 1;
-                break;
-            }
-        }
-        if (!found) {
-            WP11_Lock_UnlockRW(&token->lock);
-            return WP11_OBJECT_ALREADY_REMOVED;
-        }
-
         owner->objCnt--;
         for (curr = &owner->object; *curr != NULL; curr = &(*curr)->next) {
             if (*curr == object) {

--- a/tests/concurrent_destroy_object_test.c
+++ b/tests/concurrent_destroy_object_test.c
@@ -27,7 +27,7 @@
  * CKF_OS_LOCKING_OK). The buggy code resolved the handle to a raw WP11_Object*
  * under a released read lock, so both callers reached WP11_Object_Free on the
  * same pointer - a double free - and the loser also dereferenced the freed
- * object inside WP11_Session_RemoveObject.
+ * object inside WP11_Session_RemoveObjectByHandle.
  *
  * Each round below creates one token object and has two threads (each on its
  * own session) destroy it simultaneously. The fix must guarantee that exactly

--- a/tests/concurrent_destroy_object_test.c
+++ b/tests/concurrent_destroy_object_test.c
@@ -1,0 +1,475 @@
+/* concurrent_destroy_object_test.c
+ *
+ * Copyright (C) 2026 wolfSSL Inc.
+ *
+ * This file is part of wolfPKCS11.
+ *
+ * wolfPKCS11 is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfPKCS11 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ *
+ * Regression test for the concurrent C_DestroyObject double-free / use-after-
+ * free on a shared token object.
+ *
+ * A token object is visible to every session of an application, so two threads
+ * using two different sessions may legitimately call C_DestroyObject on the
+ * same object handle at the same time (a supported concurrent use under
+ * CKF_OS_LOCKING_OK). The buggy code resolved the handle to a raw WP11_Object*
+ * under a released read lock, so both callers reached WP11_Object_Free on the
+ * same pointer - a double free - and the loser also dereferenced the freed
+ * object inside WP11_Session_RemoveObject.
+ *
+ * Each round below creates one token object and has two threads (each on its
+ * own session) destroy it simultaneously. The fix must guarantee that exactly
+ * one destroy returns CKR_OK, the other returns CKR_OBJECT_HANDLE_INVALID, and
+ * the process does not corrupt the heap. Built with ASan this reliably aborts
+ * on the unfixed library.
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <wolfpkcs11/config.h>
+#endif
+
+#include <stdio.h>
+
+#ifndef WOLFSSL_USER_SETTINGS
+    #include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/misc.h>
+
+#ifndef WOLFPKCS11_USER_SETTINGS
+    #include <wolfpkcs11/options.h>
+#endif
+#include <wolfpkcs11/pkcs11.h>
+
+#ifndef HAVE_PKCS11_STATIC
+#include <dlfcn.h>
+#endif
+
+#include "testdata.h"
+
+#if !defined(NO_AES) && !defined(SINGLE_THREADED)
+
+#include <pthread.h>
+
+#define CONCURRENT_DESTROY_TEST_DIR "./store/concurrent_destroy_object_test"
+#define WOLFPKCS11_TOKEN_FILENAME "wp11_token_0000000000000001"
+
+#define DEFAULT_ROUNDS 250
+
+static int test_passed = 0;
+static int test_failed = 0;
+
+#ifndef HAVE_PKCS11_STATIC
+static void* dlib;
+#endif
+static CK_FUNCTION_LIST* funcList;
+static CK_SLOT_ID slot = 0;
+static const char* tokenName = "wolfpkcs11";
+static byte* soPin = (byte*)"password123456";
+static int soPinLen = 14;
+static byte* userPin = (byte*)"wolfpkcs11-test";
+static int userPinLen = 15;
+
+static CK_OBJECT_CLASS secretKeyClass = CKO_SECRET_KEY;
+static CK_BBOOL ckTrue = CK_TRUE;
+static CK_KEY_TYPE aesKeyType = CKK_AES;
+
+/* Rendezvous state shared between the main thread and the two destroyers.
+ * A busy-wait ("spin") barrier is used deliberately: cond-var wakeups have
+ * enough latency that one destroyer routinely finishes before the other
+ * starts, which hides the race. Spinning releases both threads within a few
+ * cycles of each other so their C_DestroyObject calls truly overlap. */
+static volatile int g_go = 0;           /* bumped by main to release a round   */
+static volatile int g_done = 0;         /* threads that finished current round */
+static volatile int g_stop = 0;         /* set to make the threads exit        */
+static CK_OBJECT_HANDLE g_target = CK_INVALID_HANDLE;
+static CK_RV g_rv[2];                   /* per-thread result for the round     */
+
+typedef struct {
+    int id;
+    CK_SESSION_HANDLE session;
+} thread_ctx;
+
+static CK_RV pkcs11_init(void)
+{
+    CK_RV ret;
+    CK_C_INITIALIZE_ARGS args;
+    CK_SLOT_ID slotList[16];
+    CK_ULONG slotCount = sizeof(slotList) / sizeof(slotList[0]);
+
+#ifndef HAVE_PKCS11_STATIC
+    CK_C_GetFunctionList func;
+
+    dlib = dlopen(WOLFPKCS11_DLL_FILENAME, RTLD_NOW | RTLD_LOCAL);
+    if (dlib == NULL) {
+        fprintf(stderr, "dlopen error: %s\n", dlerror());
+        return -1;
+    }
+
+    func = (CK_C_GetFunctionList)dlsym(dlib, "C_GetFunctionList");
+    if (func == NULL) {
+        fprintf(stderr, "Failed to get function list function\n");
+        dlclose(dlib);
+        return -1;
+    }
+
+    ret = func(&funcList);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "Failed to get function list: 0x%lx\n",
+            (unsigned long)ret);
+        dlclose(dlib);
+        return ret;
+    }
+#else
+    ret = C_GetFunctionList(&funcList);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "Failed to get function list: 0x%lx\n",
+            (unsigned long)ret);
+        return ret;
+    }
+#endif
+
+    XMEMSET(&args, 0, sizeof(args));
+    args.flags = CKF_OS_LOCKING_OK;
+    ret = funcList->C_Initialize(&args);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_GetSlotList(CK_TRUE, slotList, &slotCount);
+    if (ret != CKR_OK)
+        return ret;
+
+    if (slotCount > 0) {
+        slot = slotList[0];
+    } else {
+        fprintf(stderr, "No slots available\n");
+        return CKR_GENERAL_ERROR;
+    }
+
+    return ret;
+}
+
+static void pkcs11_final(void)
+{
+    if (funcList != NULL) {
+        funcList->C_Finalize(NULL);
+        funcList = NULL;
+    }
+#ifndef HAVE_PKCS11_STATIC
+    if (dlib) {
+        dlclose(dlib);
+        dlib = NULL;
+    }
+#endif
+}
+
+static CK_RV pkcs11_init_token(void)
+{
+    unsigned char label[32];
+
+    XMEMSET(label, ' ', sizeof(label));
+    XMEMCPY(label, tokenName, XSTRLEN(tokenName));
+
+    return funcList->C_InitToken(slot, soPin, soPinLen, label);
+}
+
+static CK_RV pkcs11_set_user_pin(void)
+{
+    CK_SESSION_HANDLE soSession;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+    CK_RV ret;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, &soSession);
+    if (ret != CKR_OK)
+        return ret;
+
+    ret = funcList->C_Login(soSession, CKU_SO, soPin, soPinLen);
+    if (ret != CKR_OK) {
+        funcList->C_CloseSession(soSession);
+        return ret;
+    }
+
+    ret = funcList->C_InitPIN(soSession, userPin, userPinLen);
+    funcList->C_Logout(soSession);
+    funcList->C_CloseSession(soSession);
+    return ret;
+}
+
+static CK_RV pkcs11_open_session(CK_SESSION_HANDLE* session)
+{
+    CK_RV ret;
+    int sessFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+
+    ret = funcList->C_OpenSession(slot, sessFlags, NULL, NULL, session);
+    if (ret != CKR_OK)
+        return ret;
+
+    /* Login state is token-wide: only the first session needs to log the user
+     * in, later sessions inherit it and report CKR_USER_ALREADY_LOGGED_IN. */
+    ret = funcList->C_Login(*session, CKU_USER, userPin, userPinLen);
+    if (ret != CKR_OK && ret != CKR_USER_ALREADY_LOGGED_IN) {
+        funcList->C_CloseSession(*session);
+        return ret;
+    }
+
+    return CKR_OK;
+}
+
+static void cleanup_test_files(const char* dir)
+{
+    char filepath[512];
+
+    snprintf(filepath, sizeof(filepath), "%s" PATH_SEP "%s", dir,
+             WOLFPKCS11_TOKEN_FILENAME);
+    (void)remove(filepath);
+}
+
+/* Create an AES token secret key and return its handle. */
+static CK_RV create_token_key(CK_SESSION_HANDLE session, CK_OBJECT_HANDLE* key)
+{
+    CK_ATTRIBUTE tmpl[] = {
+        { CKA_CLASS,    &secretKeyClass, sizeof(secretKeyClass) },
+        { CKA_KEY_TYPE, &aesKeyType,     sizeof(aesKeyType)     },
+        { CKA_VALUE,    aes_128_key,     sizeof(aes_128_key)    },
+        { CKA_TOKEN,    &ckTrue,         sizeof(ckTrue)         },
+    };
+    CK_ULONG tmplCnt = sizeof(tmpl) / sizeof(*tmpl);
+
+    return funcList->C_CreateObject(session, tmpl, tmplCnt, key);
+}
+
+/* Destroyer thread: each round, wait to be released, then destroy the shared
+ * target handle at the same moment as the peer thread. */
+static void* destroyer(void* arg)
+{
+    thread_ctx* ctx = (thread_ctx*)arg;
+    int last = 0;
+
+    for (;;) {
+        CK_OBJECT_HANDLE h;
+
+        /* Tight spin until main releases the next round (or asks us to stop). */
+        while (g_go == last && !g_stop) { }
+        if (g_stop)
+            break;
+        last = g_go;
+        __sync_synchronize();       /* observe g_target published before g_go */
+        h = g_target;
+
+        g_rv[ctx->id] = funcList->C_DestroyObject(ctx->session, h);
+
+        __sync_fetch_and_add(&g_done, 1);
+    }
+
+    return NULL;
+}
+
+static int concurrent_destroy_test(int rounds)
+{
+    CK_RV ret;
+    CK_SESSION_HANDLE creator = 0;
+    thread_ctx ctx[2];
+    pthread_t threads[2];
+    int result = 0;
+    int r;
+    int started = 0;
+
+    printf("\n=== Testing concurrent C_DestroyObject on a shared token "
+           "object (%d rounds) ===\n", rounds);
+
+    cleanup_test_files(CONCURRENT_DESTROY_TEST_DIR);
+
+    ret = pkcs11_init();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: pkcs11_init: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        return -1;
+    }
+
+    ret = pkcs11_init_token();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: C_InitToken: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        goto cleanup;
+    }
+
+    ret = pkcs11_set_user_pin();
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: set user PIN: 0x%lx\n", (unsigned long)ret);
+        test_failed++;
+        goto cleanup;
+    }
+
+    ret = pkcs11_open_session(&creator);
+    if (ret != CKR_OK) {
+        fprintf(stderr, "FAIL: open creator session: 0x%lx\n",
+                (unsigned long)ret);
+        test_failed++;
+        goto cleanup;
+    }
+
+    for (r = 0; r < 2; r++) {
+        ctx[r].id = r;
+        ret = pkcs11_open_session(&ctx[r].session);
+        if (ret != CKR_OK) {
+            fprintf(stderr, "FAIL: open destroyer session %d: 0x%lx\n", r,
+                    (unsigned long)ret);
+            test_failed++;
+            goto cleanup;
+        }
+        if (pthread_create(&threads[r], NULL, destroyer, &ctx[r]) != 0) {
+            fprintf(stderr, "FAIL: pthread_create %d\n", r);
+            test_failed++;
+            goto cleanup;
+        }
+        started++;
+    }
+
+    for (r = 0; r < rounds; r++) {
+        CK_OBJECT_HANDLE h = CK_INVALID_HANDLE;
+        int oks;
+
+        ret = create_token_key(creator, &h);
+        if (ret != CKR_OK) {
+            fprintf(stderr, "FAIL: create token key (round %d): 0x%lx\n", r,
+                    (unsigned long)ret);
+            test_failed++;
+            result = -1;
+            break;
+        }
+
+        /* Publish the handle, release both threads onto it simultaneously,
+         * then spin until both have returned from C_DestroyObject. */
+        g_target = h;
+        g_rv[0] = g_rv[1] = CKR_GENERAL_ERROR;
+        g_done = 0;
+        __sync_synchronize();
+        g_go = r + 1;
+        while (g_done < 2) { }
+        __sync_synchronize();
+
+        /* Exactly one destroy must win; the other must report an invalid
+         * handle. Any other combination (two successes, or a status other
+         * than CKR_OBJECT_HANDLE_INVALID for the loser) is a defect. */
+        oks = (g_rv[0] == CKR_OK) + (g_rv[1] == CKR_OK);
+        if (oks != 1) {
+            fprintf(stderr,
+                "FAIL: round %d expected exactly one CKR_OK, got rv0=0x%lx "
+                "rv1=0x%lx\n", r, (unsigned long)g_rv[0],
+                (unsigned long)g_rv[1]);
+            test_failed++;
+            result = -1;
+            break;
+        }
+        if (g_rv[0] != CKR_OK && g_rv[0] != CKR_OBJECT_HANDLE_INVALID) {
+            fprintf(stderr, "FAIL: round %d loser rv0=0x%lx\n", r,
+                    (unsigned long)g_rv[0]);
+            test_failed++;
+            result = -1;
+            break;
+        }
+        if (g_rv[1] != CKR_OK && g_rv[1] != CKR_OBJECT_HANDLE_INVALID) {
+            fprintf(stderr, "FAIL: round %d loser rv1=0x%lx\n", r,
+                    (unsigned long)g_rv[1]);
+            test_failed++;
+            result = -1;
+            break;
+        }
+
+        /* The object must really be gone: a follow-up destroy fails. */
+        ret = funcList->C_DestroyObject(creator, h);
+        if (ret != CKR_OBJECT_HANDLE_INVALID) {
+            fprintf(stderr,
+                "FAIL: round %d object still present after destroy: 0x%lx\n",
+                r, (unsigned long)ret);
+            test_failed++;
+            result = -1;
+            break;
+        }
+    }
+
+    if (result == 0) {
+        printf("PASS: %d concurrent-destroy rounds, one winner each, no "
+               "double free\n", rounds);
+        test_passed++;
+    }
+
+cleanup:
+    /* Tell the destroyer threads to exit and join them. */
+    g_stop = 1;
+    __sync_synchronize();
+    for (r = 0; r < started; r++)
+        pthread_join(threads[r], NULL);
+    for (r = 0; r < started; r++) {
+        funcList->C_Logout(ctx[r].session);
+        funcList->C_CloseSession(ctx[r].session);
+    }
+
+    if (creator != 0) {
+        funcList->C_Logout(creator);
+        funcList->C_CloseSession(creator);
+    }
+    pkcs11_final();
+    return result;
+}
+
+static void print_results(void)
+{
+    printf("\n=== Test Results ===\n");
+    printf("Tests passed: %d\n", test_passed);
+    printf("Tests failed: %d\n", test_failed);
+
+    if (test_failed == 0)
+        printf("ALL TESTS PASSED!\n");
+    else
+        printf("SOME TESTS FAILED!\n");
+}
+
+int main(int argc, char* argv[])
+{
+    int rounds = DEFAULT_ROUNDS;
+
+    if (argc > 1) {
+        int v = atoi(argv[1]);
+        if (v > 0)
+            rounds = v;
+    }
+
+#ifndef WOLFPKCS11_NO_ENV
+    XSETENV("WOLFPKCS11_TOKEN_PATH", CONCURRENT_DESTROY_TEST_DIR, 1);
+#endif
+
+    printf("=== wolfPKCS11 concurrent C_DestroyObject Test ===\n");
+
+    (void)concurrent_destroy_test(rounds);
+
+    print_results();
+
+    return (test_failed == 0) ? 0 : 1;
+}
+
+#else /* NO_AES || SINGLE_THREADED */
+
+int main(int argc, char* argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    printf("AES or threading not available, skipping concurrent "
+           "C_DestroyObject test\n");
+    return 0;
+}
+
+#endif /* !NO_AES && !SINGLE_THREADED */

--- a/tests/concurrent_destroy_object_test.c
+++ b/tests/concurrent_destroy_object_test.c
@@ -41,6 +41,7 @@
 #endif
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifndef WOLFSSL_USER_SETTINGS
     #include <wolfssl/options.h>

--- a/tests/include.am
+++ b/tests/include.am
@@ -240,6 +240,11 @@ noinst_PROGRAMS += tests/tpm_decode_bounds_test
 tests_tpm_decode_bounds_test_SOURCES = tests/tpm_decode_bounds_test.c
 tests_tpm_decode_bounds_test_LDADD =
 
+check_PROGRAMS += tests/concurrent_destroy_object_test
+noinst_PROGRAMS += tests/concurrent_destroy_object_test
+tests_concurrent_destroy_object_test_SOURCES = tests/concurrent_destroy_object_test.c
+tests_concurrent_destroy_object_test_LDADD =
+
 if BUILD_STATIC
 tests_pkcs11test_LDADD += src/libwolfpkcs11.la
 tests_pkcs11mtt_LDADD  += src/libwolfpkcs11.la
@@ -289,6 +294,7 @@ tests_aes_keywrap_pad_test_LDADD += src/libwolfpkcs11.la
 tests_mlkem_secret_scrub_test_LDADD += src/libwolfpkcs11.la
 tests_logout_token_key_zero_test_LDADD += src/libwolfpkcs11.la
 tests_tpm_decode_bounds_test_LDADD += src/libwolfpkcs11.la
+tests_concurrent_destroy_object_test_LDADD += src/libwolfpkcs11.la
 else
 tests_object_id_uniqueness_test_LDADD += src/libwolfpkcs11.la
 tests_empty_pin_store_test_LDADD += src/libwolfpkcs11.la
@@ -330,6 +336,7 @@ tests_aes_keywrap_pad_test_LDADD += src/libwolfpkcs11.la
 tests_mlkem_secret_scrub_test_LDADD += src/libwolfpkcs11.la
 tests_logout_token_key_zero_test_LDADD += src/libwolfpkcs11.la
 tests_tpm_decode_bounds_test_LDADD += src/libwolfpkcs11.la
+tests_concurrent_destroy_object_test_LDADD += src/libwolfpkcs11.la
 endif
 
 EXTRA_DIST += tests/unit.h \

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -441,19 +441,21 @@ WP11_LOCAL int WP11_Session_SetMldsaParams(WP11_Session* session, CK_VOID_PTR pa
                                            CK_ULONG paramsLen);
 WP11_LOCAL int WP11_Session_AddObject(WP11_Session* session, int onToken,
                            WP11_Object* object);
-/* Returned by WP11_Session_RemoveObject when the object was no longer linked,
- * i.e. a concurrent caller (e.g. a second C_DestroyObject on the same shared
- * token-object handle) already removed it. A positive value, distinct from the
- * 0 / negative store-status codes returned on a successful removal. The caller
- * must not free the object a second time. */
+/* Returned by WP11_Session_RemoveObjectByHandle when the object was no longer
+ * linked, i.e. a concurrent caller (e.g. a second C_DestroyObject on the same
+ * shared token-object handle) already removed it. A positive value, distinct
+ * from the 0 / negative store-status codes returned on a successful removal. The
+ * caller must not free the object a second time. */
 #define WP11_OBJECT_ALREADY_REMOVED 1
-/* Returned by WP11_Session_RemoveObject (only when checkDestroyable is set) when
- * the object is still linked but has CKA_DESTROYABLE = CK_FALSE. The object is
- * left in place and must not be freed. */
+/* Returned by WP11_Session_RemoveObjectByHandle (only when checkDestroyable is
+ * set) when the object is still linked but has CKA_DESTROYABLE = CK_FALSE. The
+ * object is left in place and must not be freed. */
 #define WP11_OBJECT_NOT_DESTROYABLE 2
-WP11_LOCAL int WP11_Session_RemoveObject(WP11_Session* session,
+WP11_LOCAL int WP11_Session_RemoveObjectByHandle(WP11_Session* session,
                               WP11_Object* object, int onToken,
                               int checkDestroyable);
+WP11_LOCAL void WP11_Session_RemoveObject(WP11_Session* session,
+                              WP11_Object* object);
 WP11_LOCAL int WP11_Object_HandleOnToken(CK_OBJECT_HANDLE handle);
 WP11_LOCAL void WP11_Slot_ClearActiveObject(WP11_Slot* slot,
                                             WP11_Object* object);

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -447,8 +447,13 @@ WP11_LOCAL int WP11_Session_AddObject(WP11_Session* session, int onToken,
  * 0 / negative store-status codes returned on a successful removal. The caller
  * must not free the object a second time. */
 #define WP11_OBJECT_ALREADY_REMOVED 1
+/* Returned by WP11_Session_RemoveObject (only when checkDestroyable is set) when
+ * the object is still linked but has CKA_DESTROYABLE = CK_FALSE. The object is
+ * left in place and must not be freed. */
+#define WP11_OBJECT_NOT_DESTROYABLE 2
 WP11_LOCAL int WP11_Session_RemoveObject(WP11_Session* session,
-                              WP11_Object* object, int onToken);
+                              WP11_Object* object, int onToken,
+                              int checkDestroyable);
 WP11_LOCAL int WP11_Object_HandleOnToken(CK_OBJECT_HANDLE handle);
 WP11_LOCAL void WP11_Slot_ClearActiveObject(WP11_Slot* slot,
                                             WP11_Object* object);

--- a/wolfpkcs11/internal.h
+++ b/wolfpkcs11/internal.h
@@ -441,7 +441,15 @@ WP11_LOCAL int WP11_Session_SetMldsaParams(WP11_Session* session, CK_VOID_PTR pa
                                            CK_ULONG paramsLen);
 WP11_LOCAL int WP11_Session_AddObject(WP11_Session* session, int onToken,
                            WP11_Object* object);
-WP11_LOCAL int WP11_Session_RemoveObject(WP11_Session* session, WP11_Object* object);
+/* Returned by WP11_Session_RemoveObject when the object was no longer linked,
+ * i.e. a concurrent caller (e.g. a second C_DestroyObject on the same shared
+ * token-object handle) already removed it. A positive value, distinct from the
+ * 0 / negative store-status codes returned on a successful removal. The caller
+ * must not free the object a second time. */
+#define WP11_OBJECT_ALREADY_REMOVED 1
+WP11_LOCAL int WP11_Session_RemoveObject(WP11_Session* session,
+                              WP11_Object* object, int onToken);
+WP11_LOCAL int WP11_Object_HandleOnToken(CK_OBJECT_HANDLE handle);
 WP11_LOCAL void WP11_Slot_ClearActiveObject(WP11_Slot* slot,
                                             WP11_Object* object);
 WP11_LOCAL void WP11_Session_GetObject(WP11_Session* session, WP11_Object** object);


### PR DESCRIPTION
C_DestroyObject resolved a handle to a raw WP11_Object* under a released read lock and then unconditionally freed it. Token objects are shared across sessions, so two sessions destroying the same handle at once (a supported concurrent use under CKF_OS_LOCKING_OK) could both reach WP11_Object_Free on the same pointer, and the losing thread also dereferenced the freed object inside WP11_Session_RemoveObject.

WP11_Session_RemoveObject now takes an onToken argument derived from the handle rather than the object, confirms the object is still linked using pointer identity under the token lock (never dereferencing a possibly freed object on the token path), and returns WP11_OBJECT_ALREADY_REMOVED when a concurrent caller already unlinked it. C_DestroyObject gates the free on that result: the loser returns CKR_OBJECT_HANDLE_INVALID without touching the object again. The successful-removal path is unchanged. Only the token lock is taken, since wp11_Session_Final already calls WP11_Session_RemoveObject while holding the slot lock.

Add WP11_Object_HandleOnToken to derive onToken from a handle, update the remaining callers to pass onToken, and add
tests/concurrent_destroy_object_test.c which races two sessions destroying one token object and checks exactly one winner per round with no double free.

F-5252